### PR TITLE
feat(print): レイアウトのドメインモデルと印刷レンダラを追加

### DIFF
--- a/src/print/__test__/buildPrintCommands.test.ts
+++ b/src/print/__test__/buildPrintCommands.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it } from '@jest/globals'
+import { buildPrintCommands, FEED_LINE_COUNT } from '../buildPrintCommands'
+import type {
+  ImageAsset,
+  Layout,
+  LayoutElement,
+  PrintData,
+  PrintDataValue,
+} from '../types'
+
+const PRINTED_AT = new Date('2026-09-07T21:34:00+09:00').getTime()
+
+const asset: ImageAsset = {
+  id: 'asset-1',
+  base64: 'AAAA',
+  width: 200,
+  imageType: 'binary',
+}
+
+const createLayout = (elements: LayoutElement[]): Layout => ({
+  id: 'layout-1',
+  name: 'テスト',
+  fields: [],
+  elements,
+  createdAt: 0,
+  updatedAt: 0,
+})
+
+const createPrintData = (
+  values: Record<string, PrintDataValue | undefined>,
+): PrintData => ({
+  id: 'print-1',
+  layoutId: 'layout-1',
+  title: 'テスト',
+  values,
+  createdAt: 0,
+  updatedAt: 0,
+})
+
+const textElement = (
+  overrides: Partial<Extract<LayoutElement, { type: 'text' }>> = {},
+): LayoutElement => ({
+  id: 'text-1',
+  type: 'text',
+  source: { kind: 'static', value: '江本光晴' },
+  fontSize: 24,
+  bold: false,
+  underline: false,
+  alignment: 'center',
+  hideWhenEmpty: true,
+  ...overrides,
+})
+
+const build = (elements: LayoutElement[], printData?: PrintData) =>
+  buildPrintCommands(createLayout(elements), printData, {
+    printedAt: PRINTED_AT,
+  })
+
+describe('buildPrintCommands', () => {
+  it('要素がなければ何も出力しない', () => {
+    expect(build([])).toEqual([])
+  })
+
+  it('末尾に紙送りを付ける', () => {
+    const commands = build([textElement()])
+    expect(commands[commands.length - 1]).toEqual({
+      type: 'lineWrap',
+      count: FEED_LINE_COUNT,
+    })
+  })
+
+  it('すべての要素が省略されたら紙送りも出力しない', () => {
+    expect(
+      build([textElement({ source: { kind: 'static', value: '' } })]),
+    ).toEqual([])
+  })
+
+  it('要素の並び順どおりに出力する', () => {
+    const commands = build([
+      { id: 'divider-1', type: 'divider', barType: 'line' },
+      { id: 'spacer-1', type: 'spacer', lines: 2 },
+    ])
+
+    expect(commands).toEqual([
+      { type: 'printHR', barType: 'line' },
+      { type: 'lineWrap', count: 2 },
+      { type: 'lineWrap', count: FEED_LINE_COUNT },
+    ])
+  })
+})
+
+describe('buildPrintCommands text要素', () => {
+  it('書式を明示してから印刷する', () => {
+    const commands = build([
+      textElement({ fontSize: 32, bold: true, alignment: 'left' }),
+    ])
+
+    expect(commands).toEqual([
+      { type: 'setAlignment', alignment: 'left' },
+      { type: 'setFontSize', size: 32 },
+      { type: 'setTextStyle', style: 'bold', enabled: true },
+      { type: 'setTextStyle', style: 'underline', enabled: false },
+      { type: 'printText', text: '江本光晴' },
+      { type: 'lineWrap', count: FEED_LINE_COUNT },
+    ])
+  })
+
+  it('書式は要素ごとに指定し直す', () => {
+    const commands = build([
+      textElement({ id: 'a', bold: true }),
+      textElement({ id: 'b', bold: false }),
+    ])
+
+    expect(
+      commands.filter(
+        (command) =>
+          command.type === 'setTextStyle' && command.style === 'bold',
+      ),
+    ).toEqual([
+      { type: 'setTextStyle', style: 'bold', enabled: true },
+      { type: 'setTextStyle', style: 'bold', enabled: false },
+    ])
+  })
+
+  it('印刷データの値を差し込む', () => {
+    const commands = build(
+      [textElement({ source: { kind: 'field', fieldId: 'field-1' } })],
+      createPrintData({ 'field-1': { kind: 'text', value: '織田信長' } }),
+    )
+
+    expect(commands).toContainEqual({ type: 'printText', text: '織田信長' })
+  })
+
+  it('hideWhenEmpty なら空の値を飛ばす', () => {
+    const commands = build(
+      [
+        textElement({ source: { kind: 'field', fieldId: 'field-1' } }),
+        { id: 'spacer-1', type: 'spacer', lines: 1 },
+      ],
+      createPrintData({}),
+    )
+
+    expect(commands).toEqual([
+      { type: 'lineWrap', count: 1 },
+      { type: 'lineWrap', count: FEED_LINE_COUNT },
+    ])
+  })
+
+  it('空白だけの値も空とみなす', () => {
+    const commands = build(
+      [textElement({ source: { kind: 'field', fieldId: 'field-1' } })],
+      createPrintData({ 'field-1': { kind: 'text', value: '　 ' } }),
+    )
+
+    expect(commands).toEqual([])
+  })
+
+  it('hideWhenEmpty が false なら空でも印刷する', () => {
+    const commands = build([
+      textElement({
+        source: { kind: 'field', fieldId: 'field-1' },
+        hideWhenEmpty: false,
+      }),
+    ])
+
+    expect(commands).toContainEqual({ type: 'printText', text: '' })
+  })
+
+  it('画像の値が入ったフィールドを参照しても文字としては扱わない', () => {
+    const commands = build(
+      [textElement({ source: { kind: 'field', fieldId: 'field-1' } })],
+      createPrintData({ 'field-1': { kind: 'image', asset } }),
+    )
+
+    expect(commands).toEqual([])
+  })
+})
+
+describe('buildPrintCommands image要素', () => {
+  const imageElement = (
+    overrides: Partial<Extract<LayoutElement, { type: 'image' }>> = {},
+  ): LayoutElement => ({
+    id: 'image-1',
+    type: 'image',
+    source: { kind: 'static', asset },
+    width: 200,
+    imageType: 'binary',
+    alignment: 'center',
+    hideWhenEmpty: true,
+    ...overrides,
+  })
+
+  it('要素側の幅と種別で印刷する', () => {
+    const commands = build([
+      imageElement({ width: 384, imageType: 'grayscale' }),
+    ])
+
+    expect(commands).toEqual([
+      { type: 'setAlignment', alignment: 'center' },
+      {
+        type: 'printImage',
+        base64: 'AAAA',
+        width: 384,
+        imageType: 'grayscale',
+      },
+      { type: 'lineWrap', count: FEED_LINE_COUNT },
+    ])
+  })
+
+  it('印刷データの画像を差し込む', () => {
+    const commands = build(
+      [imageElement({ source: { kind: 'field', fieldId: 'field-1' } })],
+      createPrintData({ 'field-1': { kind: 'image', asset } }),
+    )
+
+    expect(commands).toContainEqual({
+      type: 'printImage',
+      base64: 'AAAA',
+      width: 200,
+      imageType: 'binary',
+    })
+  })
+
+  it('画像がなければ hideWhenEmpty によらず飛ばす', () => {
+    const commands = build([
+      imageElement({
+        source: { kind: 'field', fieldId: 'field-1' },
+        hideWhenEmpty: false,
+      }),
+    ])
+
+    expect(commands).toEqual([])
+  })
+})
+
+describe('buildPrintCommands qrcode要素', () => {
+  const qrCodeElement = (
+    overrides: Partial<Extract<LayoutElement, { type: 'qrcode' }>> = {},
+  ): LayoutElement => ({
+    id: 'qr-1',
+    type: 'qrcode',
+    source: { kind: 'static', value: 'https://example.com/' },
+    moduleSize: 8,
+    errorLevel: 'low',
+    alignment: 'center',
+    hideWhenEmpty: true,
+    ...overrides,
+  })
+
+  it('設定どおりに印刷する', () => {
+    const commands = build([
+      qrCodeElement({ moduleSize: 4, errorLevel: 'high', alignment: 'left' }),
+    ])
+
+    expect(commands).toEqual([
+      { type: 'setAlignment', alignment: 'left' },
+      {
+        type: 'printQRCode',
+        text: 'https://example.com/',
+        moduleSize: 4,
+        errorLevel: 'high',
+      },
+      { type: 'lineWrap', count: FEED_LINE_COUNT },
+    ])
+  })
+
+  it('空文字は hideWhenEmpty によらず飛ばす', () => {
+    const commands = build([
+      qrCodeElement({
+        source: { kind: 'static', value: '' },
+        hideWhenEmpty: false,
+      }),
+    ])
+
+    expect(commands).toEqual([])
+  })
+})
+
+describe('buildPrintCommands columns要素', () => {
+  const columnsElement = (
+    overrides: Partial<Extract<LayoutElement, { type: 'columns' }>> = {},
+  ): LayoutElement => ({
+    id: 'columns-1',
+    type: 'columns',
+    columns: [
+      { source: { kind: 'static', value: 'X:' }, width: 10, alignment: 'left' },
+      {
+        source: { kind: 'field', fieldId: 'field-1' },
+        width: 22,
+        alignment: 'left',
+      },
+    ],
+    hideWhenEmpty: true,
+    ...overrides,
+  })
+
+  it('列ごとの幅と寄せをまとめて渡す', () => {
+    const commands = build(
+      [columnsElement()],
+      createPrintData({ 'field-1': { kind: 'text', value: '@mitsuharu_e' } }),
+    )
+
+    expect(commands).toEqual([
+      {
+        type: 'printColumns',
+        texts: ['X:', '@mitsuharu_e'],
+        widths: [10, 22],
+        alignments: ['left', 'left'],
+      },
+      { type: 'lineWrap', count: FEED_LINE_COUNT },
+    ])
+  })
+
+  it('差し込んだ値がすべて空なら、固定のラベルが残っていても飛ばす', () => {
+    expect(build([columnsElement()], createPrintData({}))).toEqual([])
+  })
+
+  it('固定値だけの行は飛ばさない', () => {
+    const commands = build([
+      columnsElement({
+        columns: [
+          {
+            source: { kind: 'static', value: '合計' },
+            width: 10,
+            alignment: 'left',
+          },
+          {
+            source: { kind: 'static', value: '0円' },
+            width: 22,
+            alignment: 'right',
+          },
+        ],
+      }),
+    ])
+
+    expect(commands).toContainEqual({
+      type: 'printColumns',
+      texts: ['合計', '0円'],
+      widths: [10, 22],
+      alignments: ['left', 'right'],
+    })
+  })
+
+  it('列がなければ飛ばす', () => {
+    expect(build([columnsElement({ columns: [] })])).toEqual([])
+  })
+})
+
+describe('buildPrintCommands timestamp要素', () => {
+  it('指定した時刻を書式に当てはめる', () => {
+    const commands = build([
+      {
+        id: 'timestamp-1',
+        type: 'timestamp',
+        format: 'YYYY/MM/DD HH:mm',
+        alignment: 'right',
+      },
+    ])
+
+    expect(commands).toEqual([
+      { type: 'setAlignment', alignment: 'right' },
+      { type: 'printText', text: '2026/09/07 21:34' },
+      { type: 'lineWrap', count: FEED_LINE_COUNT },
+    ])
+  })
+})

--- a/src/print/__test__/buildPrintCommands.test.ts
+++ b/src/print/__test__/buildPrintCommands.test.ts
@@ -221,12 +221,20 @@ describe('buildPrintCommands image要素', () => {
     })
   })
 
-  it('画像がなければ hideWhenEmpty によらず飛ばす', () => {
+  it('参照するフィールドが空なら hideWhenEmpty によらず飛ばす', () => {
     const commands = build([
       imageElement({
         source: { kind: 'field', fieldId: 'field-1' },
         hideWhenEmpty: false,
       }),
+    ])
+
+    expect(commands).toEqual([])
+  })
+
+  it('画像を選んでいない固定の要素は飛ばす', () => {
+    const commands = build([
+      imageElement({ source: { kind: 'static' }, hideWhenEmpty: false }),
     ])
 
     expect(commands).toEqual([])

--- a/src/print/__test__/factory.test.ts
+++ b/src/print/__test__/factory.test.ts
@@ -32,6 +32,15 @@ describe('createLayoutElement', () => {
   })
 })
 
+describe('createLayoutElement image', () => {
+  it('画像を選んでいない固定の供給元から始まる', () => {
+    const element = createLayoutElement('image')
+    expect(element.type === 'image' && element.source).toEqual({
+      kind: 'static',
+    })
+  })
+})
+
 describe('createLayout', () => {
   it('テキスト要素ひとつから始まる', () => {
     const layout = createLayout('名刺')

--- a/src/print/__test__/factory.test.ts
+++ b/src/print/__test__/factory.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from '@jest/globals'
+import { buildPrintCommands } from '../buildPrintCommands'
+import {
+  createLayout,
+  createLayoutElement,
+  createPrintData,
+  duplicateLayout,
+} from '../factory'
+import type { Layout, LayoutElementType } from '../types'
+
+const elementTypes: LayoutElementType[] = [
+  'text',
+  'image',
+  'qrcode',
+  'columns',
+  'divider',
+  'spacer',
+  'timestamp',
+]
+
+describe('createLayoutElement', () => {
+  it.each(elementTypes)('%s 要素をIDつきで作る', (type) => {
+    const element = createLayoutElement(type)
+    expect(element.type).toBe(type)
+    expect(element.id).not.toBe('')
+  })
+
+  it('呼ぶたびに異なるIDを振る', () => {
+    expect(createLayoutElement('text').id).not.toBe(
+      createLayoutElement('text').id,
+    )
+  })
+})
+
+describe('createLayout', () => {
+  it('テキスト要素ひとつから始まる', () => {
+    const layout = createLayout('名刺')
+    expect(layout.name).toBe('名刺')
+    expect(layout.fields).toEqual([])
+    expect(layout.elements).toHaveLength(1)
+    expect(layout.elements[0].type).toBe('text')
+  })
+})
+
+describe('createPrintData', () => {
+  it('レイアウトに紐づく空のデータを作る', () => {
+    const printData = createPrintData('layout-1', '織田信長')
+    expect(printData.layoutId).toBe('layout-1')
+    expect(printData.title).toBe('織田信長')
+    expect(printData.values).toEqual({})
+  })
+})
+
+describe('duplicateLayout', () => {
+  const original: Layout = {
+    id: 'layout-1',
+    name: '名刺',
+    fields: [
+      { id: 'field-1', key: 'name', label: '名前', valueType: 'text' },
+      { id: 'field-2', key: 'icon', label: 'アイコン', valueType: 'image' },
+    ],
+    elements: [
+      {
+        id: 'text-1',
+        type: 'text',
+        source: { kind: 'field', fieldId: 'field-1' },
+        fontSize: 32,
+        bold: true,
+        underline: false,
+        alignment: 'center',
+        hideWhenEmpty: true,
+      },
+      {
+        id: 'image-1',
+        type: 'image',
+        source: { kind: 'field', fieldId: 'field-2' },
+        width: 200,
+        imageType: 'binary',
+        alignment: 'center',
+        hideWhenEmpty: true,
+      },
+      {
+        id: 'columns-1',
+        type: 'columns',
+        columns: [
+          {
+            source: { kind: 'static', value: 'X:' },
+            width: 10,
+            alignment: 'left',
+          },
+          {
+            source: { kind: 'field', fieldId: 'field-1' },
+            width: 22,
+            alignment: 'left',
+          },
+        ],
+        hideWhenEmpty: true,
+      },
+      { id: 'divider-1', type: 'divider', barType: 'line' },
+    ],
+    createdAt: 1,
+    updatedAt: 2,
+  }
+
+  it('新しい名前とIDで複製する', () => {
+    const copied = duplicateLayout(original, '名刺のコピー')
+    expect(copied.name).toBe('名刺のコピー')
+    expect(copied.id).not.toBe(original.id)
+  })
+
+  it('要素とフィールドのIDを振り直す', () => {
+    const copied = duplicateLayout(original, 'コピー')
+
+    expect(copied.elements.map(({ id }) => id)).not.toEqual(
+      original.elements.map(({ id }) => id),
+    )
+    expect(copied.fields.map(({ id }) => id)).not.toEqual(
+      original.fields.map(({ id }) => id),
+    )
+  })
+
+  it('要素からのフィールド参照を新しいIDへ付け替える', () => {
+    const copied = duplicateLayout(original, 'コピー')
+
+    const nameFieldId = copied.fields[0].id
+    const iconFieldId = copied.fields[1].id
+
+    const text = copied.elements[0]
+    const image = copied.elements[1]
+    const columns = copied.elements[2]
+
+    expect(text.type === 'text' && text.source).toEqual({
+      kind: 'field',
+      fieldId: nameFieldId,
+    })
+    expect(image.type === 'image' && image.source).toEqual({
+      kind: 'field',
+      fieldId: iconFieldId,
+    })
+    expect(columns.type === 'columns' && columns.columns[1].source).toEqual({
+      kind: 'field',
+      fieldId: nameFieldId,
+    })
+  })
+
+  it('固定値の列はそのまま残す', () => {
+    const copied = duplicateLayout(original, 'コピー')
+    const columns = copied.elements[2]
+
+    expect(columns.type === 'columns' && columns.columns[0].source).toEqual({
+      kind: 'static',
+      value: 'X:',
+    })
+  })
+
+  it('キーやラベルなど、フィールドの中身は保つ', () => {
+    const copied = duplicateLayout(original, 'コピー')
+
+    expect(
+      copied.fields.map(({ key, label, valueType }) => ({
+        key,
+        label,
+        valueType,
+      })),
+    ).toEqual([
+      { key: 'name', label: '名前', valueType: 'text' },
+      { key: 'icon', label: 'アイコン', valueType: 'image' },
+    ])
+  })
+
+  it('複製したレイアウトは同じ印刷結果になる', () => {
+    const printedAt = 0
+
+    const copied = duplicateLayout(original, 'コピー')
+    const values = {
+      'field-1': { kind: 'text' as const, value: '江本光晴' },
+    }
+    const copiedValues = { [copied.fields[0].id]: values['field-1'] }
+
+    expect(
+      buildPrintCommands(
+        copied,
+        {
+          id: 'p2',
+          layoutId: copied.id,
+          title: '',
+          values: copiedValues,
+          createdAt: 0,
+          updatedAt: 0,
+        },
+        { printedAt },
+      ),
+    ).toEqual(
+      buildPrintCommands(
+        original,
+        {
+          id: 'p1',
+          layoutId: original.id,
+          title: '',
+          values,
+          createdAt: 0,
+          updatedAt: 0,
+        },
+        { printedAt },
+      ),
+    )
+  })
+})

--- a/src/print/buildPrintCommands.ts
+++ b/src/print/buildPrintCommands.ts
@@ -1,0 +1,195 @@
+import dayjs from 'dayjs'
+import type { PrintCommand } from './commands'
+import type {
+  ColumnsElement,
+  ImageAsset,
+  ImageElement,
+  ImageSource,
+  Layout,
+  LayoutElement,
+  PrintData,
+  QRCodeElement,
+  TextElement,
+  TextSource,
+  TimestampElement,
+} from './types'
+
+/**
+ * 印刷後に紙を送る行数
+ */
+export const FEED_LINE_COUNT = 3
+
+export type BuildPrintCommandsOptions = {
+  /**
+   * `timestamp` 要素が使う時刻。省略すると現在時刻
+   */
+  printedAt?: number
+}
+
+const resolveText = (
+  source: TextSource,
+  printData: PrintData | undefined,
+): string => {
+  if (source.kind === 'static') {
+    return source.value
+  }
+  const value = printData?.values[source.fieldId]
+  return value?.kind === 'text' ? value.value : ''
+}
+
+const resolveImage = (
+  source: ImageSource,
+  printData: PrintData | undefined,
+): ImageAsset | undefined => {
+  if (source.kind === 'static') {
+    return source.asset
+  }
+  const value = printData?.values[source.fieldId]
+  return value?.kind === 'image' ? value.asset : undefined
+}
+
+const isBlank = (text: string) => text.trim().length === 0
+
+const textCommands = (
+  element: TextElement,
+  printData: PrintData | undefined,
+): PrintCommand[] => {
+  const text = resolveText(element.source, printData)
+  if (element.hideWhenEmpty && isBlank(text)) {
+    return []
+  }
+  return [
+    { type: 'setAlignment', alignment: element.alignment },
+    { type: 'setFontSize', size: element.fontSize },
+    { type: 'setTextStyle', style: 'bold', enabled: element.bold },
+    { type: 'setTextStyle', style: 'underline', enabled: element.underline },
+    { type: 'printText', text },
+  ]
+}
+
+const imageCommands = (
+  element: ImageElement,
+  printData: PrintData | undefined,
+): PrintCommand[] => {
+  const asset = resolveImage(element.source, printData)
+  if (!asset?.base64) {
+    // 画像は差し替えられないため、hideWhenEmpty によらず出力しない
+    return []
+  }
+  return [
+    { type: 'setAlignment', alignment: element.alignment },
+    {
+      type: 'printImage',
+      base64: asset.base64,
+      width: element.width,
+      imageType: element.imageType,
+    },
+  ]
+}
+
+const qrCodeCommands = (
+  element: QRCodeElement,
+  printData: PrintData | undefined,
+): PrintCommand[] => {
+  const text = resolveText(element.source, printData)
+  if (isBlank(text)) {
+    // 空文字はQRコードに変換できない
+    return []
+  }
+  return [
+    { type: 'setAlignment', alignment: element.alignment },
+    {
+      type: 'printQRCode',
+      text,
+      moduleSize: element.moduleSize,
+      errorLevel: element.errorLevel,
+    },
+  ]
+}
+
+const columnsCommands = (
+  element: ColumnsElement,
+  printData: PrintData | undefined,
+): PrintCommand[] => {
+  if (element.columns.length === 0) {
+    return []
+  }
+
+  const texts = element.columns.map(({ source }) =>
+    resolveText(source, printData),
+  )
+
+  if (element.hideWhenEmpty) {
+    // ラベルなどの固定値は判定に含めず、差し込んだ値だけで空行か判断する
+    const filled = element.columns
+      .map((column, index) => ({ column, text: texts[index] }))
+      .filter(({ column }) => column.source.kind === 'field')
+    if (filled.length > 0 && filled.every(({ text }) => isBlank(text))) {
+      return []
+    }
+  }
+
+  return [
+    {
+      type: 'printColumns',
+      texts,
+      widths: element.columns.map(({ width }) => width),
+      alignments: element.columns.map(({ alignment }) => alignment),
+    },
+  ]
+}
+
+const timestampCommands = (
+  element: TimestampElement,
+  printedAt: number,
+): PrintCommand[] => [
+  { type: 'setAlignment', alignment: element.alignment },
+  {
+    type: 'printText',
+    text: dayjs(printedAt).locale('ja').format(element.format),
+  },
+]
+
+const elementCommands = (
+  element: LayoutElement,
+  printData: PrintData | undefined,
+  printedAt: number,
+): PrintCommand[] => {
+  switch (element.type) {
+    case 'text':
+      return textCommands(element, printData)
+    case 'image':
+      return imageCommands(element, printData)
+    case 'qrcode':
+      return qrCodeCommands(element, printData)
+    case 'columns':
+      return columnsCommands(element, printData)
+    case 'divider':
+      return [{ type: 'printHR', barType: element.barType }]
+    case 'spacer':
+      return [{ type: 'lineWrap', count: element.lines }]
+    case 'timestamp':
+      return timestampCommands(element, printedAt)
+  }
+}
+
+/**
+ * レイアウトと印刷データから、プリンターへ送る操作の並びを組み立てる
+ *
+ * ネイティブへは触れない純粋関数として、実機なしで検証できるようにしている。
+ */
+export const buildPrintCommands = (
+  layout: Layout,
+  printData?: PrintData,
+  { printedAt = dayjs().valueOf() }: BuildPrintCommandsOptions = {},
+): PrintCommand[] => {
+  const commands = layout.elements.flatMap((element) =>
+    elementCommands(element, printData, printedAt),
+  )
+
+  if (commands.length === 0) {
+    return []
+  }
+
+  return [...commands, { type: 'lineWrap', count: FEED_LINE_COUNT }]
+}

--- a/src/print/commands.ts
+++ b/src/print/commands.ts
@@ -1,0 +1,39 @@
+import type {
+  Alignment,
+  BarType,
+  PrintImageType,
+  QRErrorLevel,
+  TextStyle,
+} from '@mitsuharu/react-native-sunmi-printer-library'
+
+/**
+ * プリンターへ送る操作をひとつ表す
+ *
+ * レイアウトの解釈（`buildPrintCommands`）と、実際のプリンター呼び出しを
+ * この型で分けている。解釈側はネイティブに触らないため、実機なしで検証できる。
+ */
+export type PrintCommand =
+  | { type: 'setAlignment'; alignment: Alignment }
+  | { type: 'setFontSize'; size: number }
+  | { type: 'setTextStyle'; style: TextStyle; enabled: boolean }
+  | { type: 'printText'; text: string }
+  | {
+      type: 'printImage'
+      base64: string
+      width: number
+      imageType: PrintImageType
+    }
+  | {
+      type: 'printQRCode'
+      text: string
+      moduleSize: number
+      errorLevel: QRErrorLevel
+    }
+  | {
+      type: 'printColumns'
+      texts: string[]
+      widths: number[]
+      alignments: Alignment[]
+    }
+  | { type: 'printHR'; barType: BarType }
+  | { type: 'lineWrap'; count: number }

--- a/src/print/factory.ts
+++ b/src/print/factory.ts
@@ -41,7 +41,7 @@ export const createLayoutElement = (type: LayoutElementType): LayoutElement => {
       return {
         id,
         type: 'image',
-        source: { kind: 'field', fieldId: '' },
+        source: { kind: 'static' },
         width: DEFAULT_IMAGE_WIDTH,
         imageType: 'binary',
         alignment: 'center',

--- a/src/print/factory.ts
+++ b/src/print/factory.ts
@@ -1,0 +1,195 @@
+import dayjs from 'dayjs'
+import { FONT_SIZE } from '@/CONSTANTS'
+import { createUUID } from '@/utils/uuid'
+import type {
+  Layout,
+  LayoutElement,
+  LayoutElementType,
+  LayoutField,
+  PrintData,
+} from './types'
+
+/**
+ * タイムスタンプ要素の既定の書式
+ */
+export const DEFAULT_TIMESTAMP_FORMAT = 'YYYY/MM/DD HH:mm'
+
+/**
+ * 画像要素の既定の印刷幅
+ */
+export const DEFAULT_IMAGE_WIDTH = 200
+
+/**
+ * 追加した直後の要素を作る
+ */
+export const createLayoutElement = (type: LayoutElementType): LayoutElement => {
+  const id = createUUID()
+
+  switch (type) {
+    case 'text':
+      return {
+        id,
+        type: 'text',
+        source: { kind: 'static', value: '' },
+        fontSize: FONT_SIZE.DEFAULT,
+        bold: false,
+        underline: false,
+        alignment: 'center',
+        hideWhenEmpty: true,
+      }
+    case 'image':
+      return {
+        id,
+        type: 'image',
+        source: { kind: 'field', fieldId: '' },
+        width: DEFAULT_IMAGE_WIDTH,
+        imageType: 'binary',
+        alignment: 'center',
+        hideWhenEmpty: true,
+      }
+    case 'qrcode':
+      return {
+        id,
+        type: 'qrcode',
+        source: { kind: 'static', value: '' },
+        moduleSize: 8,
+        errorLevel: 'low',
+        alignment: 'center',
+        hideWhenEmpty: true,
+      }
+    case 'columns':
+      return {
+        id,
+        type: 'columns',
+        columns: [
+          {
+            source: { kind: 'static', value: '' },
+            width: 10,
+            alignment: 'left',
+          },
+          {
+            source: { kind: 'static', value: '' },
+            width: 22,
+            alignment: 'left',
+          },
+        ],
+        hideWhenEmpty: true,
+      }
+    case 'divider':
+      return { id, type: 'divider', barType: 'line' }
+    case 'spacer':
+      return { id, type: 'spacer', lines: 1 }
+    case 'timestamp':
+      return {
+        id,
+        type: 'timestamp',
+        format: DEFAULT_TIMESTAMP_FORMAT,
+        alignment: 'right',
+      }
+  }
+}
+
+/**
+ * 差し込み口を作る
+ */
+export const createLayoutField = (
+  values: Partial<Omit<LayoutField, 'id'>> = {},
+): LayoutField => ({
+  id: createUUID(),
+  key: '',
+  label: '',
+  valueType: 'text',
+  ...values,
+})
+
+/**
+ * 新規レイアウトを作る
+ *
+ * 初期状態はテキスト要素ひとつだけとする。
+ */
+export const createLayout = (name = ''): Layout => {
+  const now = dayjs().valueOf()
+  return {
+    id: createUUID(),
+    name,
+    fields: [],
+    elements: [createLayoutElement('text')],
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+/**
+ * レイアウトに紐づく新規の印刷データを作る
+ */
+export const createPrintData = (layoutId: string, title = ''): PrintData => {
+  const now = dayjs().valueOf()
+  return {
+    id: createUUID(),
+    layoutId,
+    title,
+    values: {},
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+/**
+ * レイアウトを複製する
+ *
+ * 要素とフィールドは新しいIDを振り直し、要素からのフィールド参照も付け替える。
+ */
+export const duplicateLayout = (layout: Layout, name: string): Layout => {
+  const now = dayjs().valueOf()
+  const fieldIdMap = new Map(
+    layout.fields.map((field) => [field.id, createUUID()]),
+  )
+  const nextFieldId = (fieldId: string) => fieldIdMap.get(fieldId) ?? fieldId
+
+  return {
+    id: createUUID(),
+    name,
+    createdAt: now,
+    updatedAt: now,
+    fields: layout.fields.map((field) => ({
+      ...field,
+      id: nextFieldId(field.id),
+    })),
+    elements: layout.elements.map((element) => {
+      const id = createUUID()
+      switch (element.type) {
+        case 'text':
+        case 'qrcode':
+        case 'image':
+          return element.source.kind === 'field'
+            ? {
+                ...element,
+                id,
+                source: {
+                  ...element.source,
+                  fieldId: nextFieldId(element.source.fieldId),
+                },
+              }
+            : { ...element, id }
+        case 'columns':
+          return {
+            ...element,
+            id,
+            columns: element.columns.map((column) =>
+              column.source.kind === 'field'
+                ? {
+                    ...column,
+                    source: {
+                      ...column.source,
+                      fieldId: nextFieldId(column.source.fieldId),
+                    },
+                  }
+                : column,
+            ),
+          }
+        default:
+          return { ...element, id }
+      }
+    }),
+  }
+}

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1,0 +1,4 @@
+export * from './buildPrintCommands'
+export * from './commands'
+export * from './factory'
+export * from './types'

--- a/src/print/types.ts
+++ b/src/print/types.ts
@@ -44,9 +44,11 @@ export type TextSource =
 
 /**
  * 画像要素の供給元
+ *
+ * 固定の画像は、要素を追加した直後など、まだ画像を選んでいない状態を取り得る。
  */
 export type ImageSource =
-  | { kind: 'static'; asset: ImageAsset }
+  | { kind: 'static'; asset?: ImageAsset }
   | { kind: 'field'; fieldId: string }
 
 type ElementBase = {

--- a/src/print/types.ts
+++ b/src/print/types.ts
@@ -1,0 +1,167 @@
+import type {
+  Alignment,
+  BarType,
+  PrintImageType,
+  QRErrorLevel,
+} from '@mitsuharu/react-native-sunmi-printer-library'
+
+/**
+ * 印刷する画像
+ *
+ * `width` と `imageType` は取り込んだときの設定で、印刷時は要素側の指定が優先される。
+ */
+export type ImageAsset = {
+  id: string
+  base64: string
+  width: number
+  imageType: PrintImageType
+}
+
+/**
+ * 印刷データへ入力できる値の種類
+ */
+export type FieldValueType = 'text' | 'multilineText' | 'url' | 'image'
+
+/**
+ * レイアウトが宣言する差し込み口
+ */
+export type LayoutField = {
+  id: string
+  /**
+   * 印刷データ側で参照する識別子。レイアウト内で一意
+   */
+  key: string
+  label: string
+  valueType: FieldValueType
+}
+
+/**
+ * 文字を持つ要素の供給元
+ */
+export type TextSource =
+  | { kind: 'static'; value: string }
+  | { kind: 'field'; fieldId: string }
+
+/**
+ * 画像要素の供給元
+ */
+export type ImageSource =
+  | { kind: 'static'; asset: ImageAsset }
+  | { kind: 'field'; fieldId: string }
+
+type ElementBase = {
+  id: string
+}
+
+/**
+ * 供給元を持つ要素は、値が空なら印刷を飛ばせる
+ */
+type OmittableElement = ElementBase & {
+  hideWhenEmpty: boolean
+}
+
+export type TextElement = OmittableElement & {
+  type: 'text'
+  source: TextSource
+  fontSize: number
+  bold: boolean
+  underline: boolean
+  alignment: Alignment
+}
+
+export type ImageElement = OmittableElement & {
+  type: 'image'
+  source: ImageSource
+  width: number
+  imageType: PrintImageType
+  alignment: Alignment
+}
+
+export type QRCodeElement = OmittableElement & {
+  type: 'qrcode'
+  source: TextSource
+  /**
+   * QRコードの1マスの大きさ（1〜16）
+   */
+  moduleSize: number
+  errorLevel: QRErrorLevel
+  alignment: Alignment
+}
+
+export type LayoutColumn = {
+  source: TextSource
+  /**
+   * 半角文字に換算した列幅
+   */
+  width: number
+  alignment: Alignment
+}
+
+export type ColumnsElement = OmittableElement & {
+  type: 'columns'
+  columns: LayoutColumn[]
+}
+
+export type DividerElement = ElementBase & {
+  type: 'divider'
+  barType: BarType
+}
+
+export type SpacerElement = ElementBase & {
+  type: 'spacer'
+  lines: number
+}
+
+export type TimestampElement = ElementBase & {
+  type: 'timestamp'
+  /**
+   * dayjs の書式
+   */
+  format: string
+  alignment: Alignment
+}
+
+export type LayoutElement =
+  | TextElement
+  | ImageElement
+  | QRCodeElement
+  | ColumnsElement
+  | DividerElement
+  | SpacerElement
+  | TimestampElement
+
+export type LayoutElementType = LayoutElement['type']
+
+/**
+ * 印刷の体裁
+ */
+export type Layout = {
+  id: string
+  name: string
+  fields: LayoutField[]
+  elements: LayoutElement[]
+  createdAt: number
+  updatedAt: number
+}
+
+/**
+ * 印刷データがフィールドへ入れる値
+ */
+export type PrintDataValue =
+  | { kind: 'text'; value: string }
+  | { kind: 'image'; asset: ImageAsset }
+
+/**
+ * レイアウトへ差し込む値のひとまとまり
+ */
+export type PrintData = {
+  id: string
+  layoutId: string
+  title: string
+  /**
+   * `LayoutField.id` をキーにした値
+   */
+  values: Record<string, PrintDataValue | undefined>
+  createdAt: number
+  updatedAt: number
+}


### PR DESCRIPTION
> [!NOTE]
> [#464](https://github.com/mitsuharu/mobile-printer/pull/464) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

自由レイアウト印刷のドメインモデルと、レイアウトを印刷操作へ変換する処理を追加します。**既存の印刷経路には一切手を入れていません。** 差し替えは PR8 で行います。

- `src/print/types.ts` … レイアウト・要素・フィールド・印刷データの型
- `src/print/commands.ts` … プリンターへ送る操作を表す `PrintCommand`
- `src/print/buildPrintCommands.ts` … `(layout, printData) => PrintCommand[]`
- `src/print/factory.ts` … 新規作成の初期値とレイアウトの複製

## 設計

**要素は現行のプロフィール印刷が出力しているものを一般化しました。** `text` / `image` / `qrcode` / `columns`（SNS行）/ `divider`（`hr`）/ `spacer`（`lineWrap`）/ `timestamp` の7種類で、現行 `printProfile` の出力はすべて表現できます。

**レイアウト解釈とプリンター呼び出しを `PrintCommand` で分離しました。** `buildPrintCommands` はネイティブに触らない純粋関数なので、印刷結果の解釈を実機なしで検証できます。時刻も引数で渡すため `timestamp` 要素も決定的にテストできます。

**書式は要素ごとに必ず指定し直します。** プリンター側の太字・下線・寄せは設定が残るため、前の要素の書式が漏れないよう毎回明示します。

**空値の扱い**は現行の `if (alias)` 相当を `hideWhenEmpty` として持たせました。`columns` は固定のラベル（`X:` など）を判定に含めず、差し込んだ値だけで空行か判断します。画像とQRコードは値がないと印刷自体が成立しないため、`hideWhenEmpty` によらず飛ばします。

**複製**ではフィールドと要素のIDを振り直したうえで、要素からのフィールド参照も付け替えます。複製前後で同じ印刷結果になることをテストで固定しています。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし（警告72件、いずれも既存） |
| `TZ=Asia/Tokyo yarn test --runInBand` | 6 suites / 114 tests 成功（本PRで37件追加） |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

依存関係もネイティブも印刷動作も変えていないため、実機確認は行っていません。実際に印刷して確かめるのは、この処理を印刷経路へ繋ぐ PR8 になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
