### PR TITLE
feat(layout): レイアウト一覧の画面を追加

### DIFF
--- a/src/routes/main.constraint.ts
+++ b/src/routes/main.constraint.ts
@@ -2,6 +2,7 @@ export const MainName = {
   Home: 'Home',
   Form: 'Form',
   Printer: 'Printer',
+  LayoutList: 'LayoutList',
 } as const
 
 export type MainName = (typeof MainName)[keyof typeof MainName]

--- a/src/routes/main.params.ts
+++ b/src/routes/main.params.ts
@@ -4,4 +4,5 @@ export type MainParams = {
   Home: undefined
   Form: { submission: Submission }
   Printer: undefined
+  LayoutList: undefined
 }

--- a/src/routes/main.routes.tsx
+++ b/src/routes/main.routes.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import type React from 'react'
 import { Form } from '@/screens/Form'
 import { Home } from '@/screens/Home'
+import { LayoutList } from '@/screens/LayoutList'
 import { Printer } from '@/screens/Printer'
 import { MainName } from './main.constraint'
 import type { MainParams } from './main.params'
@@ -19,6 +20,7 @@ const Routes: React.FC = () => {
       <Stack.Screen name={MainName.Home} component={Home} />
       <Stack.Screen name={MainName.Form} component={Form} />
       <Stack.Screen name={MainName.Printer} component={Printer} />
+      <Stack.Screen name={MainName.LayoutList} component={LayoutList} />
     </Stack.Navigator>
   )
 }

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -31,6 +31,7 @@ type ComponentProps = Props & {
   onPressPrintProfileRandomly: () => void
   onPressNewSubmission: () => void
   onNavigateToPrinter: () => void
+  onNavigateToLayoutList: () => void
 }
 
 const Component: React.FC<ComponentProps> = ({
@@ -42,6 +43,7 @@ const Component: React.FC<ComponentProps> = ({
   onPressPrintProfileRandomly,
   onPressNewSubmission,
   onNavigateToPrinter,
+  onNavigateToLayoutList,
 }) => {
   const styles = useStyles()
 
@@ -59,6 +61,14 @@ const Component: React.FC<ComponentProps> = ({
         <Cell
           title="その他"
           onPress={onNavigateToPrinter}
+          inactive={isEditable}
+          accessory="disclosure"
+        />
+      </Section>
+      <Section title="レイアウト印刷">
+        <Cell
+          title="レイアウトを管理する"
+          onPress={onNavigateToLayoutList}
           inactive={isEditable}
           accessory="disclosure"
         />
@@ -150,6 +160,10 @@ const Container: React.FC<Props> = (props) => {
     navigation.navigate('Printer')
   }, [navigation])
 
+  const onNavigateToLayoutList = useCallback(() => {
+    navigation.navigate('LayoutList')
+  }, [navigation])
+
   return (
     <Component
       {...props}
@@ -162,6 +176,7 @@ const Container: React.FC<Props> = (props) => {
         onPressPrintProfileRandomly,
         onPressNewSubmission,
         onNavigateToPrinter,
+        onNavigateToLayoutList,
       }}
     />
   )

--- a/src/screens/LayoutList/index.tsx
+++ b/src/screens/LayoutList/index.tsx
@@ -1,0 +1,176 @@
+import { useIsFocused, useNavigation } from '@react-navigation/native'
+import type React from 'react'
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { ScrollView, StyleSheet, type ViewStyle } from 'react-native'
+import AlertAsync from 'react-native-alert-async'
+import { makeStyles } from 'react-native-swag-styles'
+import { useDispatch, useSelector } from 'react-redux'
+import { MESSAGE } from '@/CONSTANTS'
+import { InputDialog } from '@/components/Dialog'
+import { Cell, Section } from '@/components/List'
+import type { Layout } from '@/print'
+import { createLayout } from '@/print'
+import { selectDatabaseIsReady } from '@/redux/modules/database/selectors'
+import { selectLayouts } from '@/redux/modules/layout/selectors'
+import {
+  deleteLayout,
+  duplicateLayout,
+  fetchLayouts,
+  saveLayout,
+} from '@/redux/modules/layout/slice'
+import { formatDateTime } from '@/utils/day'
+import { styleType } from '@/utils/styles'
+
+type Props = {}
+type ComponentProps = Props & {
+  layouts: Layout[]
+  isDialogVisible: boolean
+  onPressLayout: (layout: Layout) => void
+  onPressAdd: () => void
+  onSubmitName: (name: string) => void
+  onCancelDialog: () => void
+}
+
+const Component: React.FC<ComponentProps> = ({
+  layouts,
+  isDialogVisible,
+  onPressLayout,
+  onPressAdd,
+  onSubmitName,
+  onCancelDialog,
+}) => {
+  const styles = useStyles()
+
+  return (
+    <>
+      <ScrollView style={styles.scrollView}>
+        <Section title="レイアウト">
+          {layouts.length === 0 ? (
+            <Cell
+              title="レイアウトがありません"
+              description="下の「レイアウトを追加する」から作成してください"
+              inactive={true}
+            />
+          ) : (
+            layouts.map((layout) => (
+              <Cell
+                key={layout.id}
+                title={layout.name}
+                description={`要素${layout.elements.length}個・${formatDateTime(layout.updatedAt)}`}
+                accessory="disclosure"
+                onPress={() => onPressLayout(layout)}
+              />
+            ))
+          )}
+        </Section>
+        <Section title="操作">
+          <Cell title="レイアウトを追加する" onPress={onPressAdd} />
+        </Section>
+      </ScrollView>
+      <InputDialog
+        isVisible={isDialogVisible}
+        title="レイアウトの追加"
+        description="レイアウトの名前を入力してください"
+        onPress={onSubmitName}
+        onCancel={onCancelDialog}
+      />
+    </>
+  )
+}
+
+const Container: React.FC<Props> = (props) => {
+  const navigation = useNavigation()
+  const dispatch = useDispatch()
+  const isFocused = useIsFocused()
+
+  const layouts = useSelector(selectLayouts)
+  const isDatabaseReady = useSelector(selectDatabaseIsReady)
+
+  const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: 'レイアウト' })
+  }, [navigation])
+
+  // SQLite が情報源なので、表示するたびに読み直す
+  useEffect(() => {
+    if (isFocused && isDatabaseReady) {
+      dispatch(fetchLayouts())
+    }
+  }, [dispatch, isFocused, isDatabaseReady])
+
+  const onPressLayout = useCallback(
+    async (layout: Layout) => {
+      try {
+        const action = await AlertAsync(layout.name, '操作を選んでください', [
+          { text: '複製する', onPress: () => 'duplicate' },
+          { text: '削除する', onPress: () => 'delete', style: 'destructive' },
+          { text: MESSAGE.CANCEL, onPress: () => undefined, style: 'cancel' },
+        ])
+
+        if (action === 'duplicate') {
+          dispatch(duplicateLayout(layout))
+          return
+        }
+
+        if (action === 'delete') {
+          const confirmed = await AlertAsync(
+            '確認',
+            `「${layout.name}」を削除しますか？\nこのレイアウトの印刷データも消えます。`,
+            [
+              { text: MESSAGE.NO, onPress: () => false, style: 'cancel' },
+              { text: MESSAGE.YES, onPress: () => true },
+            ],
+          )
+          if (confirmed) {
+            dispatch(deleteLayout(layout))
+          }
+        }
+      } catch (e: any) {
+        console.warn('onPressLayout', e)
+      }
+    },
+    [dispatch],
+  )
+
+  const onPressAdd = useCallback(() => {
+    setIsDialogVisible(true)
+  }, [])
+
+  const onSubmitName = useCallback(
+    (name: string) => {
+      setIsDialogVisible(false)
+      dispatch(saveLayout(createLayout(name.trim() || '新しいレイアウト')))
+    },
+    [dispatch],
+  )
+
+  const onCancelDialog = useCallback(() => {
+    setIsDialogVisible(false)
+  }, [])
+
+  return (
+    <Component
+      {...props}
+      {...{
+        layouts,
+        isDialogVisible,
+        onPressLayout,
+        onPressAdd,
+        onSubmitName,
+        onCancelDialog,
+      }}
+    />
+  )
+}
+
+export { Container as LayoutList }
+
+const useStyles = makeStyles(() => {
+  const styles = StyleSheet.create({
+    scrollView: styleType<ViewStyle>({
+      flex: 1,
+    }),
+  })
+  return styles
+})

--- a/src/utils/__test__/day.test.ts
+++ b/src/utils/__test__/day.test.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs'
 import MockDate from 'mockdate'
 import {
+  formatDateTime,
   isChristmasDuration,
   isMoreThanOneDay,
   isNewYearDuration,
@@ -19,6 +20,25 @@ describe('timeStamp', () => {
   ])('if unixTime is %s then timeStamp returns %s', (unixTime, expected) => {
     MockDate.set(unixTime * 1000)
     expect(timeStamp()).toEqual(expected)
+  })
+})
+
+describe('formatDateTime', () => {
+  it.each<[unixTime: number, expected: string]>([
+    [1666008000, '2022/10/17 21:00'],
+    [1560000000, '2019/06/08 22:20'],
+    [2560000000, '2051/02/15 00:06'],
+  ])(
+    'if unixTime is %s then formatDateTime returns %s',
+    (unixTime, expected) => {
+      expect(formatDateTime(unixTime * 1000)).toEqual(expected)
+    },
+  )
+
+  it('現在時刻ではなく引数の時刻を表示する', () => {
+    MockDate.set(0)
+    expect(formatDateTime(1666008000 * 1000)).toEqual('2022/10/17 21:00')
+    MockDate.reset()
   })
 })
 

--- a/src/utils/day.ts
+++ b/src/utils/day.ts
@@ -6,6 +6,12 @@ import dayjs from 'dayjs'
 export const timeStamp = () => dayjs().locale('ja').format('YYYY/MM/DD HH:mm')
 
 /**
+ * @returns 引数のunix時間（ミリ秒）を YYYY/MM/DD HH:mm で表示する
+ */
+export const formatDateTime = (milliUnixTime: number) =>
+  dayjs(milliUnixTime).locale('ja').format('YYYY/MM/DD HH:mm')
+
+/**
  * 引数のunix時間（ミリ秒）と今を比較して、日付が変わったか判定する
  */
 export const isMoreThanOneDay = (milliUnixTime: number) => {


### PR DESCRIPTION
> [!NOTE]
> [#467](https://github.com/mitsuharu/mobile-printer/pull/467) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

レイアウトの一覧・追加・複製・削除を行う画面と、ホームからの導線を追加します。既存のプロフィール印刷は据え置きです（撤去は PR9）。

- `src/screens/LayoutList/` … 一覧画面
- ホームに「レイアウト印刷 > レイアウトを管理する」を追加
- `formatDateTime` … 一覧で更新日時を表示するため

## 仕様

- SQLite が情報源のため、画面を表示するたびに読み直します
- 削除は「このレイアウトの印刷データも消えます」と伝えてから確認を取ります
- 一覧のセルをタップしたときの操作は、**要素の編集画面を追加する PR6 までの暫定**として複製と削除のみです。PR6 でセルのタップを編集画面への遷移に変えます

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし（警告76件、いずれも既存） |
| `TZ=Asia/Tokyo yarn test --runInBand` | 10 suites / 151 tests 成功（本PRで4件追加） |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

画面を追加するPRなので、実機で一通り操作しました。

1. ホームから「レイアウトを管理する」で遷移し、空の状態が表示される
2. 「レイアウトを追加する」で名前を入力して作成 → 一覧に「要素1個・2026/09/07 22:22」として現れる
3. セルをタップ → 複製 → 「〜のコピー」が更新の新しい順で先頭に並ぶ
4. コピーをタップ → 削除 → 確認のうえ一覧から消える
5. 端末の `mobile_printer.sqlite` を取り出し、`layouts` に元のレイアウトのみが残り、削除したコピーの `layout_elements` も連鎖削除で消えていることを確認

印刷そのものは変更していないため、印刷の確認は行っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
