### PR TITLE
feat(layout): 要素の個別編集と差し込み口の定義を追加

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
-import { useCallback, useRef } from 'react'
-import { View } from 'react-native'
+import { useCallback, useEffect, useRef } from 'react'
+import { type KeyboardTypeOptions, View } from 'react-native'
 import RnDialog from 'react-native-dialog'
 import { MESSAGE } from '@/CONSTANTS'
 
@@ -8,6 +8,14 @@ type Props = {
   title?: string
   description?: string
   isVisible: boolean
+
+  /**
+   * 入力欄の初期値
+   */
+  defaultValue?: string
+
+  keyboardType?: KeyboardTypeOptions
+
   onCancel?: () => void
   onPress?: (text: string) => void
 }
@@ -17,14 +25,23 @@ const Component: React.FC<ComponentProps> = ({
   isVisible,
   title,
   description,
+  defaultValue,
+  keyboardType,
   onCancel,
   onPress,
 }) => {
-  const textRef = useRef('')
+  const textRef = useRef(defaultValue ?? '')
   const onChangeText = useCallback(
     (text: string) => (textRef.current = text),
     [],
   )
+
+  // 開くたびに初期値へ戻す
+  useEffect(() => {
+    if (isVisible) {
+      textRef.current = defaultValue ?? ''
+    }
+  }, [isVisible, defaultValue])
 
   return (
     <View>
@@ -32,9 +49,10 @@ const Component: React.FC<ComponentProps> = ({
         <RnDialog.Title>{title}</RnDialog.Title>
         <RnDialog.Description>{description}</RnDialog.Description>
         <RnDialog.Input
-          defaultValue={undefined}
+          key={`${isVisible}-${defaultValue}`}
+          defaultValue={defaultValue}
           onChangeText={onChangeText}
-          keyboardType={'url'}
+          keyboardType={keyboardType ?? 'url'}
           autoCapitalize={'none'}
         />
         <RnDialog.Button label={MESSAGE.NO} onPress={() => onCancel?.()} />

--- a/src/components/Modal/ListPickerModal/index.tsx
+++ b/src/components/Modal/ListPickerModal/index.tsx
@@ -1,0 +1,118 @@
+import type React from 'react'
+import {
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  useColorScheme,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import { makeStyles } from 'react-native-swag-styles'
+import { COLOR, MESSAGE } from '@/CONSTANTS'
+import { Button } from '@/components/Button'
+import { Cell } from '@/components/List'
+import { styleType } from '@/utils/styles'
+
+export type ListPickerItem<T> = {
+  value: T
+  title: string
+  description?: string
+}
+
+type Props<T> = {
+  visible: boolean
+  title: string
+  items: ListPickerItem<T>[]
+  selected?: T
+  onSelect: (value: T) => void
+  onCancel: () => void
+}
+
+/**
+ * 一覧から1つ選ぶモーダル
+ *
+ * @note
+ * AndroidのAlertは3つまでしかボタンを表示できず、選択肢が切り捨てられる。
+ * 選択肢が4つ以上になり得るものは、このモーダルで選ばせる。
+ */
+export const ListPickerModal = <T,>({
+  visible,
+  title,
+  items,
+  selected,
+  onSelect,
+  onCancel,
+}: Props<T>): React.ReactElement => {
+  const styles = useStyles()
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="fade"
+      transparent={true}
+      onRequestClose={onCancel}
+    >
+      <View style={styles.container}>
+        <View style={styles.modal}>
+          <Text style={styles.title}>{title}</Text>
+          <ScrollView style={styles.list}>
+            {items.map((item) => (
+              <Cell
+                key={String(item.value)}
+                title={item.title}
+                description={item.description}
+                onPress={() => onSelect(item.value)}
+                accessory={item.value === selected ? 'check' : 'disclosure'}
+              />
+            ))}
+          </ScrollView>
+          <Button
+            onPress={onCancel}
+            text={MESSAGE.CANCEL}
+            style={styles.buttonView}
+            textStyle={styles.buttonText}
+          />
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+const useStyles = makeStyles(useColorScheme, (colorScheme) => {
+  const styles = StyleSheet.create({
+    container: styleType<ViewStyle>({
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'rgba(0,0,0,0.4)',
+    }),
+    modal: styleType<ViewStyle>({
+      width: '85%',
+      maxHeight: '70%',
+      borderRadius: 8,
+      overflow: 'hidden',
+      backgroundColor: COLOR(colorScheme).BACKGROUND.PRIMARY,
+    }),
+    title: styleType<TextStyle>({
+      paddingHorizontal: 16,
+      paddingVertical: 16,
+      fontSize: 18,
+      fontWeight: 'bold',
+      color: COLOR(colorScheme).TEXT.PRIMARY,
+    }),
+    list: styleType<ViewStyle>({
+      flexGrow: 0,
+    }),
+    buttonView: styleType<ViewStyle>({
+      paddingVertical: 16,
+      alignItems: 'center',
+    }),
+    buttonText: styleType<TextStyle>({
+      fontSize: 16,
+      color: COLOR(colorScheme).TEXT.PRIMARY,
+    }),
+  })
+  return styles
+})

--- a/src/print/__test__/mutations.test.ts
+++ b/src/print/__test__/mutations.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from '@jest/globals'
+import {
+  addElement,
+  isFieldReferenced,
+  moveElement,
+  removeElement,
+  removeField,
+  replaceElement,
+  upsertField,
+} from '../mutations'
+import type { Layout, LayoutElement } from '../types'
+
+const text = (id: string): LayoutElement => ({
+  id,
+  type: 'text',
+  source: { kind: 'field', fieldId: 'field-1' },
+  fontSize: 24,
+  bold: false,
+  underline: false,
+  alignment: 'center',
+  hideWhenEmpty: true,
+})
+
+const layout: Layout = {
+  id: 'layout-1',
+  name: '名刺',
+  fields: [
+    { id: 'field-1', key: 'name', label: '名前', valueType: 'text' },
+    { id: 'field-2', key: 'icon', label: 'アイコン', valueType: 'image' },
+  ],
+  elements: [
+    text('a'),
+    { id: 'b', type: 'divider', barType: 'line' },
+    { id: 'c', type: 'spacer', lines: 1 },
+  ],
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+describe('addElement', () => {
+  it('末尾に足す', () => {
+    const next = addElement(layout, { id: 'd', type: 'spacer', lines: 2 })
+    expect(next.elements.map(({ id }) => id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+})
+
+describe('replaceElement', () => {
+  it('同じIDの要素を差し替える', () => {
+    const next = replaceElement(layout, {
+      id: 'b',
+      type: 'divider',
+      barType: 'wave',
+    })
+    expect(next.elements[1]).toEqual({
+      id: 'b',
+      type: 'divider',
+      barType: 'wave',
+    })
+  })
+
+  it('ほかの要素と並び順は変えない', () => {
+    const next = replaceElement(layout, {
+      id: 'b',
+      type: 'divider',
+      barType: 'wave',
+    })
+    expect(next.elements.map(({ id }) => id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('IDが一致しなければ何も変わらない', () => {
+    const next = replaceElement(layout, { id: 'x', type: 'spacer', lines: 9 })
+    expect(next.elements).toEqual(layout.elements)
+  })
+})
+
+describe('removeElement', () => {
+  it('指定した要素を取り除く', () => {
+    expect(removeElement(layout, 'b').elements.map(({ id }) => id)).toEqual([
+      'a',
+      'c',
+    ])
+  })
+})
+
+describe('moveElement', () => {
+  it('前から後ろへ動かす', () => {
+    expect(moveElement(layout, 0, 2).elements.map(({ id }) => id)).toEqual([
+      'b',
+      'c',
+      'a',
+    ])
+  })
+
+  it('後ろから前へ動かす', () => {
+    expect(moveElement(layout, 2, 0).elements.map(({ id }) => id)).toEqual([
+      'c',
+      'a',
+      'b',
+    ])
+  })
+
+  it('同じ位置なら何も変わらない', () => {
+    expect(moveElement(layout, 1, 1)).toBe(layout)
+  })
+
+  it('範囲の外は何も変わらない', () => {
+    expect(moveElement(layout, 0, 5)).toBe(layout)
+    expect(moveElement(layout, -1, 0)).toBe(layout)
+  })
+})
+
+describe('upsertField', () => {
+  it('新しい差し込み口を足す', () => {
+    const next = upsertField(layout, {
+      id: 'field-3',
+      key: 'qr',
+      label: 'QR',
+      valueType: 'url',
+    })
+    expect(next.fields.map(({ id }) => id)).toEqual([
+      'field-1',
+      'field-2',
+      'field-3',
+    ])
+  })
+
+  it('同じIDなら差し替える', () => {
+    const next = upsertField(layout, {
+      id: 'field-1',
+      key: 'fullName',
+      label: '氏名',
+      valueType: 'text',
+    })
+    expect(next.fields).toHaveLength(2)
+    expect(next.fields[0].label).toBe('氏名')
+  })
+})
+
+describe('removeField', () => {
+  const withColumns: Layout = {
+    ...layout,
+    elements: [
+      ...layout.elements,
+      {
+        id: 'd',
+        type: 'columns',
+        columns: [
+          {
+            source: { kind: 'static', value: 'X:' },
+            width: 10,
+            alignment: 'left',
+          },
+          {
+            source: { kind: 'field', fieldId: 'field-1' },
+            width: 22,
+            alignment: 'left',
+          },
+        ],
+        hideWhenEmpty: true,
+      },
+      {
+        id: 'e',
+        type: 'image',
+        source: { kind: 'field', fieldId: 'field-2' },
+        width: 200,
+        imageType: 'binary',
+        alignment: 'center',
+        hideWhenEmpty: true,
+      },
+    ],
+  }
+
+  it('差し込み口を取り除く', () => {
+    expect(
+      removeField(withColumns, 'field-1').fields.map(({ id }) => id),
+    ).toEqual(['field-2'])
+  })
+
+  it('参照していた文字の要素を固定値へ戻す', () => {
+    const next = removeField(withColumns, 'field-1')
+    const element = next.elements[0]
+    expect(element.type === 'text' && element.source).toEqual({
+      kind: 'static',
+      value: '',
+    })
+  })
+
+  it('参照していた列を固定値へ戻す', () => {
+    const next = removeField(withColumns, 'field-1')
+    const element = next.elements[3]
+    expect(element.type === 'columns' && element.columns[1].source).toEqual({
+      kind: 'static',
+      value: '',
+    })
+  })
+
+  it('参照していた画像を画像未選択へ戻す', () => {
+    const next = removeField(withColumns, 'field-2')
+    const element = next.elements[4]
+    expect(element.type === 'image' && element.source).toEqual({
+      kind: 'static',
+    })
+  })
+
+  it('ほかの差し込み口への参照は残す', () => {
+    const next = removeField(withColumns, 'field-2')
+    const element = next.elements[0]
+    expect(element.type === 'text' && element.source).toEqual({
+      kind: 'field',
+      fieldId: 'field-1',
+    })
+  })
+
+  it('固定値の列はそのまま残す', () => {
+    const next = removeField(withColumns, 'field-1')
+    const element = next.elements[3]
+    expect(element.type === 'columns' && element.columns[0].source).toEqual({
+      kind: 'static',
+      value: 'X:',
+    })
+  })
+})
+
+describe('isFieldReferenced', () => {
+  it('参照している要素があれば true', () => {
+    expect(isFieldReferenced(layout, 'field-1')).toBe(true)
+  })
+
+  it('参照している要素がなければ false', () => {
+    expect(isFieldReferenced(layout, 'field-2')).toBe(false)
+  })
+})

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1,4 +1,5 @@
 export * from './buildPrintCommands'
 export * from './commands'
 export * from './factory'
+export * from './mutations'
 export * from './types'

--- a/src/print/mutations.ts
+++ b/src/print/mutations.ts
@@ -1,0 +1,137 @@
+import type {
+  ImageSource,
+  Layout,
+  LayoutElement,
+  LayoutField,
+  TextSource,
+} from './types'
+
+const touch = (layout: Layout, elements: LayoutElement[]): Layout => ({
+  ...layout,
+  elements,
+})
+
+/**
+ * 要素を末尾に足す
+ */
+export const addElement = (layout: Layout, element: LayoutElement): Layout =>
+  touch(layout, [...layout.elements, element])
+
+/**
+ * 同じIDの要素を差し替える
+ */
+export const replaceElement = (
+  layout: Layout,
+  element: LayoutElement,
+): Layout =>
+  touch(
+    layout,
+    layout.elements.map((value) => (value.id === element.id ? element : value)),
+  )
+
+/**
+ * 要素を取り除く
+ */
+export const removeElement = (layout: Layout, elementId: string): Layout =>
+  touch(
+    layout,
+    layout.elements.filter(({ id }) => id !== elementId),
+  )
+
+/**
+ * 要素の位置を入れ替える
+ */
+export const moveElement = (
+  layout: Layout,
+  from: number,
+  to: number,
+): Layout => {
+  const { elements } = layout
+  if (
+    from === to ||
+    from < 0 ||
+    to < 0 ||
+    from >= elements.length ||
+    to >= elements.length
+  ) {
+    return layout
+  }
+
+  const next = [...elements]
+  const [moved] = next.splice(from, 1)
+  next.splice(to, 0, moved)
+  return touch(layout, next)
+}
+
+const clearTextSource = (source: TextSource, fieldId: string): TextSource =>
+  source.kind === 'field' && source.fieldId === fieldId
+    ? { kind: 'static', value: '' }
+    : source
+
+const clearImageSource = (source: ImageSource, fieldId: string): ImageSource =>
+  source.kind === 'field' && source.fieldId === fieldId
+    ? { kind: 'static' }
+    : source
+
+/**
+ * 差し込み口を足すか、同じIDのものを差し替える
+ */
+export const upsertField = (layout: Layout, field: LayoutField): Layout => {
+  const exists = layout.fields.some(({ id }) => id === field.id)
+  return {
+    ...layout,
+    fields: exists
+      ? layout.fields.map((value) => (value.id === field.id ? field : value))
+      : [...layout.fields, field],
+  }
+}
+
+/**
+ * 差し込み口を取り除く
+ *
+ * 参照している要素は参照先を失うため、あわせて固定値へ戻す。
+ */
+export const removeField = (layout: Layout, fieldId: string): Layout => ({
+  ...layout,
+  fields: layout.fields.filter(({ id }) => id !== fieldId),
+  elements: layout.elements.map((element) => {
+    switch (element.type) {
+      case 'text':
+      case 'qrcode':
+        return { ...element, source: clearTextSource(element.source, fieldId) }
+      case 'image':
+        return { ...element, source: clearImageSource(element.source, fieldId) }
+      case 'columns':
+        return {
+          ...element,
+          columns: element.columns.map((column) => ({
+            ...column,
+            source: clearTextSource(column.source, fieldId),
+          })),
+        }
+      default:
+        return element
+    }
+  }),
+})
+
+/**
+ * 差し込み口を参照している要素があるか調べる
+ */
+export const isFieldReferenced = (layout: Layout, fieldId: string): boolean =>
+  layout.elements.some((element) => {
+    switch (element.type) {
+      case 'text':
+      case 'qrcode':
+      case 'image':
+        return (
+          element.source.kind === 'field' && element.source.fieldId === fieldId
+        )
+      case 'columns':
+        return element.columns.some(
+          ({ source }) => source.kind === 'field' && source.fieldId === fieldId,
+        )
+      default:
+        return false
+    }
+  })

--- a/src/routes/main.constraint.ts
+++ b/src/routes/main.constraint.ts
@@ -4,6 +4,8 @@ export const MainName = {
   Printer: 'Printer',
   LayoutList: 'LayoutList',
   LayoutEditor: 'LayoutEditor',
+  ElementEditor: 'ElementEditor',
+  LayoutFields: 'LayoutFields',
 } as const
 
 export type MainName = (typeof MainName)[keyof typeof MainName]

--- a/src/routes/main.params.ts
+++ b/src/routes/main.params.ts
@@ -6,4 +6,6 @@ export type MainParams = {
   Printer: undefined
   LayoutList: undefined
   LayoutEditor: { layoutId: string }
+  ElementEditor: { layoutId: string; elementId: string }
+  LayoutFields: { layoutId: string }
 }

--- a/src/routes/main.routes.tsx
+++ b/src/routes/main.routes.tsx
@@ -1,8 +1,10 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import type React from 'react'
+import { ElementEditor } from '@/screens/ElementEditor'
 import { Form } from '@/screens/Form'
 import { Home } from '@/screens/Home'
 import { LayoutEditor } from '@/screens/LayoutEditor'
+import { LayoutFields } from '@/screens/LayoutFields'
 import { LayoutList } from '@/screens/LayoutList'
 import { Printer } from '@/screens/Printer'
 import { MainName } from './main.constraint'
@@ -23,6 +25,8 @@ const Routes: React.FC = () => {
       <Stack.Screen name={MainName.Printer} component={Printer} />
       <Stack.Screen name={MainName.LayoutList} component={LayoutList} />
       <Stack.Screen name={MainName.LayoutEditor} component={LayoutEditor} />
+      <Stack.Screen name={MainName.ElementEditor} component={ElementEditor} />
+      <Stack.Screen name={MainName.LayoutFields} component={LayoutFields} />
     </Stack.Navigator>
   )
 }

--- a/src/screens/ElementEditor/ImageSourceSection.tsx
+++ b/src/screens/ElementEditor/ImageSourceSection.tsx
@@ -1,0 +1,115 @@
+import type React from 'react'
+import { useCallback } from 'react'
+import { StyleSheet, View, type ViewStyle } from 'react-native'
+import { BASE64 } from '@/CONSTANTS'
+import { Base64ImageView } from '@/components/Base64ImageView'
+import { Cell, Section } from '@/components/List'
+import type { ImageSource, Layout } from '@/print'
+import { styleType } from '@/utils/styles'
+import { createUUID } from '@/utils/uuid'
+import { PickerCell } from './rows'
+
+type Props = {
+  layout: Layout
+  source: ImageSource
+  width: number
+  onChange: (source: ImageSource) => void
+}
+
+type SourceKind = ImageSource['kind']
+
+/**
+ * 画像の供給元を編集する
+ */
+export const ImageSourceSection: React.FC<Props> = ({
+  layout,
+  source,
+  width,
+  onChange,
+}) => {
+  const onChangeKind = useCallback(
+    (kind: SourceKind) => {
+      if (kind === source.kind) {
+        return
+      }
+      onChange(
+        kind === 'static'
+          ? { kind: 'static' }
+          : { kind: 'field', fieldId: layout.fields[0]?.id ?? '' },
+      )
+    },
+    [layout.fields, onChange, source.kind],
+  )
+
+  const onChangeBase64 = useCallback(
+    (base64: string) => {
+      onChange({
+        kind: 'static',
+        asset: {
+          // 画像を選び直したら別のアセットとして保存する
+          id: createUUID(),
+          base64,
+          width,
+          imageType: 'binary',
+        },
+      })
+    },
+    [onChange, width],
+  )
+
+  return (
+    <Section title="内容">
+      <PickerCell
+        title="内容の決め方"
+        value={source.kind}
+        items={[
+          {
+            value: 'static' as SourceKind,
+            title: 'レイアウトに直接置く',
+            description: 'どの印刷データでも同じ画像になります',
+          },
+          {
+            value: 'field' as SourceKind,
+            title: '印刷データから差し込む',
+            description: '印刷データごとに画像を変えられます',
+          },
+        ]}
+        onChange={onChangeKind}
+      />
+      {source.kind === 'static' ? (
+        <View style={styles.imageView}>
+          <Base64ImageView
+            base64={source.asset?.base64}
+            onChange={onChangeBase64}
+          />
+        </View>
+      ) : layout.fields.length === 0 ? (
+        <Cell
+          title="差し込み口がありません"
+          description="レイアウトの「差し込み口」から追加してください"
+          inactive={true}
+        />
+      ) : (
+        <PickerCell
+          title="差し込み口"
+          value={source.fieldId}
+          items={layout.fields.map((field) => ({
+            value: field.id,
+            title: field.label || field.key,
+            description: field.key,
+          }))}
+          onChange={(fieldId) => onChange({ kind: 'field', fieldId })}
+        />
+      )}
+    </Section>
+  )
+}
+
+const styles = StyleSheet.create({
+  imageView: styleType<ViewStyle>({
+    alignItems: 'center',
+    paddingVertical: 16,
+    width: '100%',
+    minHeight: BASE64.PROFILE_ICON_SIZE,
+  }),
+})

--- a/src/screens/ElementEditor/TextSourceSection.tsx
+++ b/src/screens/ElementEditor/TextSourceSection.tsx
@@ -1,0 +1,84 @@
+import type React from 'react'
+import { useCallback } from 'react'
+import { Cell, Section } from '@/components/List'
+import type { Layout, TextSource } from '@/print'
+import { PickerCell, TextValueCell } from './rows'
+
+type Props = {
+  title: string
+  layout: Layout
+  source: TextSource
+  onChange: (source: TextSource) => void
+}
+
+type SourceKind = TextSource['kind']
+
+/**
+ * 文字の供給元（固定値か、印刷データからの差し込みか）を編集する
+ */
+export const TextSourceSection: React.FC<Props> = ({
+  title,
+  layout,
+  source,
+  onChange,
+}) => {
+  const onChangeKind = useCallback(
+    (kind: SourceKind) => {
+      if (kind === source.kind) {
+        return
+      }
+      onChange(
+        kind === 'static'
+          ? { kind: 'static', value: '' }
+          : { kind: 'field', fieldId: layout.fields[0]?.id ?? '' },
+      )
+    },
+    [layout.fields, onChange, source.kind],
+  )
+
+  return (
+    <Section title={title}>
+      <PickerCell
+        title="内容の決め方"
+        value={source.kind}
+        items={[
+          {
+            value: 'static' as SourceKind,
+            title: 'レイアウトに直接書く',
+            description: 'どの印刷データでも同じ内容になります',
+          },
+          {
+            value: 'field' as SourceKind,
+            title: '印刷データから差し込む',
+            description: '印刷データごとに内容を変えられます',
+          },
+        ]}
+        onChange={onChangeKind}
+      />
+      {source.kind === 'static' ? (
+        <TextValueCell
+          title="内容"
+          value={source.value}
+          onChange={(value) => onChange({ kind: 'static', value })}
+        />
+      ) : layout.fields.length === 0 ? (
+        <Cell
+          title="差し込み口がありません"
+          description="レイアウトの「差し込み口」から追加してください"
+          inactive={true}
+        />
+      ) : (
+        <PickerCell
+          title="差し込み口"
+          value={source.fieldId}
+          items={layout.fields.map((field) => ({
+            value: field.id,
+            title: field.label || field.key,
+            description: field.key,
+          }))}
+          onChange={(fieldId) => onChange({ kind: 'field', fieldId })}
+        />
+      )}
+    </Section>
+  )
+}

--- a/src/screens/ElementEditor/index.tsx
+++ b/src/screens/ElementEditor/index.tsx
@@ -1,0 +1,396 @@
+import {
+  type RouteProp,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native'
+import type React from 'react'
+import { useCallback, useLayoutEffect, useMemo } from 'react'
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  useColorScheme,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import AlertAsync from 'react-native-alert-async'
+import { makeStyles } from 'react-native-swag-styles'
+import { useDispatch, useSelector } from 'react-redux'
+import { BASE64, COLOR, MESSAGE } from '@/CONSTANTS'
+import { Cell, Section } from '@/components/List'
+import type { Layout, LayoutElement } from '@/print'
+import { removeElement, replaceElement } from '@/print'
+import { selectLayoutById } from '@/redux/modules/layout/selectors'
+import { saveLayout } from '@/redux/modules/layout/slice'
+import type { MainParams } from '@/routes/main.params'
+import { styleType } from '@/utils/styles'
+import { describeElementType } from '../LayoutEditor/describeElement'
+import { ImageSourceSection } from './ImageSourceSection'
+import {
+  alignmentItems,
+  barTypeItems,
+  errorLevelItems,
+  fontSizeItems,
+  imageTypeItems,
+  timestampFormatItems,
+} from './options'
+import { NumberValueCell, PickerCell, TextValueCell } from './rows'
+import { TextSourceSection } from './TextSourceSection'
+
+type ParamsProps = RouteProp<MainParams, 'ElementEditor'>
+
+type Props = {}
+type ComponentProps = Props & {
+  layout: Layout | undefined
+  element: LayoutElement | undefined
+  onChange: (element: LayoutElement) => void
+  onDelete: () => void
+}
+
+const hideWhenEmptyCell = (
+  element: Extract<LayoutElement, { hideWhenEmpty: boolean }>,
+  onChange: (element: LayoutElement) => void,
+) => (
+  <Cell
+    title="内容が空なら印刷しない"
+    accessory="switch"
+    switchValue={element.hideWhenEmpty}
+    onSwitchValueChange={(hideWhenEmpty) =>
+      onChange({ ...element, hideWhenEmpty })
+    }
+  />
+)
+
+const Component: React.FC<ComponentProps> = ({
+  layout,
+  element,
+  onChange,
+  onDelete,
+}) => {
+  const styles = useStyles()
+
+  if (!layout || !element) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>要素が見つかりません</Text>
+      </View>
+    )
+  }
+
+  return (
+    <ScrollView style={styles.scrollView}>
+      {element.type === 'text' && (
+        <>
+          <TextSourceSection
+            title="内容"
+            layout={layout}
+            source={element.source}
+            onChange={(source) => onChange({ ...element, source })}
+          />
+          <Section title="体裁">
+            <PickerCell
+              title="文字の大きさ"
+              value={element.fontSize}
+              items={fontSizeItems}
+              onChange={(fontSize) => onChange({ ...element, fontSize })}
+            />
+            <PickerCell
+              title="寄せ"
+              value={element.alignment}
+              items={alignmentItems}
+              onChange={(alignment) => onChange({ ...element, alignment })}
+            />
+            <Cell
+              title="太字"
+              accessory="switch"
+              switchValue={element.bold}
+              onSwitchValueChange={(bold) => onChange({ ...element, bold })}
+            />
+            <Cell
+              title="下線"
+              accessory="switch"
+              switchValue={element.underline}
+              onSwitchValueChange={(underline) =>
+                onChange({ ...element, underline })
+              }
+            />
+            {hideWhenEmptyCell(element, onChange)}
+          </Section>
+        </>
+      )}
+
+      {element.type === 'image' && (
+        <>
+          <ImageSourceSection
+            layout={layout}
+            source={element.source}
+            width={element.width}
+            onChange={(source) => onChange({ ...element, source })}
+          />
+          <Section title="体裁">
+            <NumberValueCell
+              title="印刷する幅"
+              value={element.width}
+              unit="px"
+              min={1}
+              max={BASE64.MAX_SIZE}
+              onChange={(width) => onChange({ ...element, width })}
+            />
+            <PickerCell
+              title="変換方法"
+              value={element.imageType}
+              items={imageTypeItems}
+              onChange={(imageType) => onChange({ ...element, imageType })}
+            />
+            <PickerCell
+              title="寄せ"
+              value={element.alignment}
+              items={alignmentItems}
+              onChange={(alignment) => onChange({ ...element, alignment })}
+            />
+            {hideWhenEmptyCell(element, onChange)}
+          </Section>
+        </>
+      )}
+
+      {element.type === 'qrcode' && (
+        <>
+          <TextSourceSection
+            title="内容"
+            layout={layout}
+            source={element.source}
+            onChange={(source) => onChange({ ...element, source })}
+          />
+          <Section title="体裁">
+            <NumberValueCell
+              title="大きさ"
+              value={element.moduleSize}
+              min={1}
+              max={16}
+              onChange={(moduleSize) => onChange({ ...element, moduleSize })}
+            />
+            <PickerCell
+              title="誤り訂正レベル"
+              value={element.errorLevel}
+              items={errorLevelItems}
+              onChange={(errorLevel) => onChange({ ...element, errorLevel })}
+            />
+            <PickerCell
+              title="寄せ"
+              value={element.alignment}
+              items={alignmentItems}
+              onChange={(alignment) => onChange({ ...element, alignment })}
+            />
+            {hideWhenEmptyCell(element, onChange)}
+          </Section>
+        </>
+      )}
+
+      {element.type === 'columns' &&
+        element.columns.map((column, index) => (
+          <View key={`column-${element.id}-${index}`}>
+            <TextSourceSection
+              title={`${index + 1}列目`}
+              layout={layout}
+              source={column.source}
+              onChange={(source) =>
+                onChange({
+                  ...element,
+                  columns: element.columns.map((value, i) =>
+                    i === index ? { ...value, source } : value,
+                  ),
+                })
+              }
+            />
+            <Section>
+              <NumberValueCell
+                title={`${index + 1}列目の幅`}
+                value={column.width}
+                unit="文字"
+                min={1}
+                max={48}
+                onChange={(width) =>
+                  onChange({
+                    ...element,
+                    columns: element.columns.map((value, i) =>
+                      i === index ? { ...value, width } : value,
+                    ),
+                  })
+                }
+              />
+              <PickerCell
+                title={`${index + 1}列目の寄せ`}
+                value={column.alignment}
+                items={alignmentItems}
+                onChange={(alignment) =>
+                  onChange({
+                    ...element,
+                    columns: element.columns.map((value, i) =>
+                      i === index ? { ...value, alignment } : value,
+                    ),
+                  })
+                }
+              />
+            </Section>
+          </View>
+        ))}
+
+      {element.type === 'columns' && (
+        <Section title="列">
+          <Cell
+            title="列を追加する"
+            onPress={() =>
+              onChange({
+                ...element,
+                columns: [
+                  ...element.columns,
+                  {
+                    source: { kind: 'static', value: '' },
+                    width: 10,
+                    alignment: 'left',
+                  },
+                ],
+              })
+            }
+          />
+          {element.columns.length > 1 && (
+            <Cell
+              title="最後の列を削除する"
+              onPress={() =>
+                onChange({
+                  ...element,
+                  columns: element.columns.slice(0, -1),
+                })
+              }
+            />
+          )}
+          {hideWhenEmptyCell(element, onChange)}
+        </Section>
+      )}
+
+      {element.type === 'divider' && (
+        <Section title="体裁">
+          <PickerCell
+            title="線の種類"
+            value={element.barType}
+            items={barTypeItems}
+            onChange={(barType) => onChange({ ...element, barType })}
+          />
+        </Section>
+      )}
+
+      {element.type === 'spacer' && (
+        <Section title="体裁">
+          <NumberValueCell
+            title="空ける行数"
+            value={element.lines}
+            unit="行"
+            min={1}
+            max={20}
+            onChange={(lines) => onChange({ ...element, lines })}
+          />
+        </Section>
+      )}
+
+      {element.type === 'timestamp' && (
+        <Section title="体裁">
+          <PickerCell
+            title="書式"
+            value={element.format}
+            items={timestampFormatItems}
+            onChange={(format) => onChange({ ...element, format })}
+          />
+          <TextValueCell
+            title="書式を直接指定する"
+            value={element.format}
+            dialogDescription="dayjs の書式で指定します"
+            onChange={(format) => onChange({ ...element, format })}
+          />
+          <PickerCell
+            title="寄せ"
+            value={element.alignment}
+            items={alignmentItems}
+            onChange={(alignment) => onChange({ ...element, alignment })}
+          />
+        </Section>
+      )}
+
+      <Section title="操作">
+        <Cell title="この要素を削除する" onPress={onDelete} />
+      </Section>
+    </ScrollView>
+  )
+}
+
+const Container: React.FC<Props> = (props) => {
+  const navigation = useNavigation()
+  const dispatch = useDispatch()
+
+  const {
+    params: { layoutId, elementId },
+  } = useRoute<ParamsProps>()
+
+  const selector = useMemo(() => selectLayoutById(layoutId), [layoutId])
+  const layout = useSelector(selector)
+  const element = layout?.elements.find(({ id }) => id === elementId)
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      title: element ? describeElementType(element.type) : '要素',
+    })
+  }, [navigation, element])
+
+  const onChange = useCallback(
+    (next: LayoutElement) => {
+      if (!layout) {
+        return
+      }
+      dispatch(saveLayout(replaceElement(layout, next)))
+    },
+    [dispatch, layout],
+  )
+
+  const onDelete = useCallback(async () => {
+    if (!layout || !element) {
+      return
+    }
+    try {
+      const confirmed = await AlertAsync(
+        '確認',
+        `${describeElementType(element.type)}の要素を削除しますか？`,
+        [
+          { text: MESSAGE.NO, onPress: () => false, style: 'cancel' },
+          { text: MESSAGE.YES, onPress: () => true },
+        ],
+      )
+      if (confirmed) {
+        dispatch(saveLayout(removeElement(layout, element.id)))
+        navigation.goBack()
+      }
+    } catch (e: any) {
+      console.warn('onDelete', e)
+    }
+  }, [dispatch, element, layout, navigation])
+
+  return <Component {...props} {...{ layout, element, onChange, onDelete }} />
+}
+
+export { Container as ElementEditor }
+
+const useStyles = makeStyles(useColorScheme, (colorScheme) => {
+  const styles = StyleSheet.create({
+    scrollView: styleType<ViewStyle>({
+      flex: 1,
+    }),
+    empty: styleType<ViewStyle>({
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    }),
+    emptyText: styleType<TextStyle>({
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+  })
+  return styles
+})

--- a/src/screens/ElementEditor/options.ts
+++ b/src/screens/ElementEditor/options.ts
@@ -1,0 +1,67 @@
+import type {
+  Alignment,
+  BarType,
+  PrintImageType,
+  QRErrorLevel,
+} from '@mitsuharu/react-native-sunmi-printer-library'
+import { FONT_SIZE } from '@/CONSTANTS'
+import type { ListPickerItem } from '@/components/Modal/ListPickerModal'
+import type { FieldValueType } from '@/print'
+
+export const alignmentItems: ListPickerItem<Alignment>[] = [
+  { value: 'left', title: '左寄せ' },
+  { value: 'center', title: '中央' },
+  { value: 'right', title: '右寄せ' },
+]
+
+export const fontSizeItems: ListPickerItem<number>[] = [
+  {
+    value: FONT_SIZE.DEFAULT,
+    title: '標準',
+    description: `${FONT_SIZE.DEFAULT}px`,
+  },
+  { value: FONT_SIZE.LARGE, title: '大', description: `${FONT_SIZE.LARGE}px` },
+]
+
+export const imageTypeItems: ListPickerItem<PrintImageType>[] = [
+  { value: 'binary', title: '白黒', description: '二値化して印刷する' },
+  { value: 'grayscale', title: 'グレースケール' },
+]
+
+export const barTypeItems: ListPickerItem<BarType>[] = [
+  { value: 'line', title: '実線' },
+  { value: 'double', title: '二重線' },
+  { value: 'dots', title: '点線' },
+  { value: 'wave', title: '波線' },
+  { value: 'plus', title: 'プラス' },
+  { value: 'star', title: '星' },
+]
+
+export const errorLevelItems: ListPickerItem<QRErrorLevel>[] = [
+  { value: 'low', title: '低', description: '情報量を多くできる' },
+  { value: 'middle', title: '中' },
+  { value: 'quartile', title: 'やや高' },
+  { value: 'high', title: '高', description: '汚れに強い' },
+]
+
+export const fieldValueTypeItems: ListPickerItem<FieldValueType>[] = [
+  { value: 'text', title: 'テキスト' },
+  { value: 'multilineText', title: '複数行テキスト' },
+  { value: 'url', title: 'URL' },
+  { value: 'image', title: '画像' },
+]
+
+export const timestampFormatItems: ListPickerItem<string>[] = [
+  {
+    value: 'YYYY/MM/DD HH:mm',
+    title: '日付と時刻',
+    description: '2026/09/07 22:34',
+  },
+  { value: 'YYYY/MM/DD', title: '日付', description: '2026/09/07' },
+  { value: 'HH:mm', title: '時刻', description: '22:34' },
+  {
+    value: 'YYYY/MM/DD HH:mm:ss',
+    title: '秒まで',
+    description: '2026/09/07 22:34:00',
+  },
+]

--- a/src/screens/ElementEditor/rows/NumberValueCell.tsx
+++ b/src/screens/ElementEditor/rows/NumberValueCell.tsx
@@ -1,0 +1,50 @@
+import type React from 'react'
+import { useCallback } from 'react'
+import { TextValueCell } from './TextValueCell'
+
+type Props = {
+  title: string
+  value: number
+  unit?: string
+  min: number
+  max: number
+  onChange: (value: number) => void
+}
+
+/**
+ * タップして数値を入れ直すセル
+ *
+ * 範囲の外や数値でない入力は捨てて、元の値を保つ。
+ */
+export const NumberValueCell: React.FC<Props> = ({
+  title,
+  value,
+  unit,
+  min,
+  max,
+  onChange,
+}) => {
+  const onChangeText = useCallback(
+    (text: string) => {
+      const next = Number(text.trim())
+      if (!Number.isFinite(next) || !Number.isInteger(next)) {
+        return
+      }
+      if (next < min || next > max) {
+        return
+      }
+      onChange(next)
+    },
+    [max, min, onChange],
+  )
+
+  return (
+    <TextValueCell
+      title={title}
+      value={`${value}${unit ?? ''}`}
+      dialogDescription={`${min}〜${max} の数値を入力してください`}
+      keyboardType="number-pad"
+      onChange={onChangeText}
+    />
+  )
+}

--- a/src/screens/ElementEditor/rows/PickerCell.tsx
+++ b/src/screens/ElementEditor/rows/PickerCell.tsx
@@ -1,0 +1,54 @@
+import type React from 'react'
+import { useCallback, useState } from 'react'
+import { Cell } from '@/components/List'
+import {
+  type ListPickerItem,
+  ListPickerModal,
+} from '@/components/Modal/ListPickerModal'
+
+type Props<T> = {
+  title: string
+  value: T
+  items: ListPickerItem<T>[]
+  onChange: (value: T) => void
+}
+
+/**
+ * タップして一覧から選び直すセル
+ */
+export const PickerCell = <T,>({
+  title,
+  value,
+  items,
+  onChange,
+}: Props<T>): React.ReactElement => {
+  const [isVisible, setIsVisible] = useState<boolean>(false)
+
+  const onSelect = useCallback(
+    (next: T) => {
+      setIsVisible(false)
+      onChange(next)
+    },
+    [onChange],
+  )
+
+  return (
+    <>
+      <Cell
+        title={title}
+        description={
+          items.find((item) => item.value === value)?.title ?? '（未設定）'
+        }
+        onPress={() => setIsVisible(true)}
+      />
+      <ListPickerModal
+        visible={isVisible}
+        title={title}
+        items={items}
+        selected={value}
+        onSelect={onSelect}
+        onCancel={() => setIsVisible(false)}
+      />
+    </>
+  )
+}

--- a/src/screens/ElementEditor/rows/TextValueCell.tsx
+++ b/src/screens/ElementEditor/rows/TextValueCell.tsx
@@ -1,0 +1,57 @@
+import type React from 'react'
+import { useCallback, useState } from 'react'
+import type { KeyboardTypeOptions } from 'react-native'
+import { InputDialog } from '@/components/Dialog'
+import { Cell } from '@/components/List'
+
+type Props = {
+  title: string
+  value: string
+  placeholder?: string
+  dialogDescription?: string
+  keyboardType?: KeyboardTypeOptions
+  onChange: (value: string) => void
+}
+
+/**
+ * タップして文字を入れ直すセル
+ */
+export const TextValueCell: React.FC<Props> = ({
+  title,
+  value,
+  placeholder,
+  dialogDescription,
+  keyboardType,
+  onChange,
+}) => {
+  const [isVisible, setIsVisible] = useState<boolean>(false)
+
+  const onPress = useCallback(() => setIsVisible(true), [])
+  const onCancel = useCallback(() => setIsVisible(false), [])
+  const onSubmit = useCallback(
+    (next: string) => {
+      setIsVisible(false)
+      onChange(next)
+    },
+    [onChange],
+  )
+
+  return (
+    <>
+      <Cell
+        title={title}
+        description={value === '' ? (placeholder ?? '（未設定）') : value}
+        onPress={onPress}
+      />
+      <InputDialog
+        isVisible={isVisible}
+        title={title}
+        description={dialogDescription}
+        defaultValue={value}
+        keyboardType={keyboardType}
+        onPress={onSubmit}
+        onCancel={onCancel}
+      />
+    </>
+  )
+}

--- a/src/screens/ElementEditor/rows/index.ts
+++ b/src/screens/ElementEditor/rows/index.ts
@@ -1,0 +1,3 @@
+export * from './NumberValueCell'
+export * from './PickerCell'
+export * from './TextValueCell'

--- a/src/screens/LayoutEditor/index.tsx
+++ b/src/screens/LayoutEditor/index.tsx
@@ -13,23 +13,20 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
-import AlertAsync from 'react-native-alert-async'
 import ReorderableList, {
   type ReorderableListReorderEvent,
-  reorderItems,
 } from 'react-native-reorderable-list'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { makeStyles } from 'react-native-swag-styles'
 import { useDispatch, useSelector } from 'react-redux'
-import { COLOR, MESSAGE } from '@/CONSTANTS'
+import { COLOR } from '@/CONSTANTS'
 import { Cell, Section } from '@/components/List'
 import type { Layout, LayoutElement, LayoutElementType } from '@/print'
-import { createLayoutElement } from '@/print'
+import { addElement, createLayoutElement, moveElement } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
 import { saveLayout } from '@/redux/modules/layout/slice'
 import type { MainParams } from '@/routes/main.params'
 import { styleType } from '@/utils/styles'
-import { describeElementType } from './describeElement'
 import { ElementCell } from './ElementCell'
 import { ElementTypePickerModal } from './ElementTypePickerModal'
 
@@ -41,6 +38,7 @@ type ComponentProps = Props & {
   onReorder: (event: ReorderableListReorderEvent) => void
   onPressElement: (element: LayoutElement) => void
   onPressAdd: () => void
+  onPressFields: () => void
   isPickerVisible: boolean
   onSelectElementType: (type: LayoutElementType) => void
   onCancelPicker: () => void
@@ -51,6 +49,7 @@ const Component: React.FC<ComponentProps> = ({
   onReorder,
   onPressElement,
   onPressAdd,
+  onPressFields,
   isPickerVisible,
   onSelectElementType,
   onCancelPicker,
@@ -89,6 +88,12 @@ const Component: React.FC<ComponentProps> = ({
       />
       <Section>
         <Cell title="要素を追加する" onPress={onPressAdd} />
+        <Cell
+          title="差し込み口"
+          description={`${layout.fields.length}個`}
+          onPress={onPressFields}
+          accessory="disclosure"
+        />
       </Section>
       <ElementTypePickerModal
         visible={isPickerVisible}
@@ -119,44 +124,24 @@ const Container: React.FC<Props> = (props) => {
       if (!layout) {
         return
       }
-      dispatch(
-        saveLayout({
-          ...layout,
-          elements: reorderItems(layout.elements, from, to),
-        }),
-      )
+      dispatch(saveLayout(moveElement(layout, from, to)))
     },
     [dispatch, layout],
   )
 
   const onPressElement = useCallback(
-    async (element: LayoutElement) => {
-      if (!layout) {
-        return
-      }
-      try {
-        const confirmed = await AlertAsync(
-          describeElementType(element.type),
-          'この要素を削除しますか？',
-          [
-            { text: MESSAGE.NO, onPress: () => false, style: 'cancel' },
-            { text: MESSAGE.YES, onPress: () => true },
-          ],
-        )
-        if (confirmed) {
-          dispatch(
-            saveLayout({
-              ...layout,
-              elements: layout.elements.filter(({ id }) => id !== element.id),
-            }),
-          )
-        }
-      } catch (e: any) {
-        console.warn('onPressElement', e)
-      }
+    (element: LayoutElement) => {
+      navigation.navigate('ElementEditor', {
+        layoutId,
+        elementId: element.id,
+      })
     },
-    [dispatch, layout],
+    [navigation, layoutId],
   )
+
+  const onPressFields = useCallback(() => {
+    navigation.navigate('LayoutFields', { layoutId })
+  }, [navigation, layoutId])
 
   const [isPickerVisible, setIsPickerVisible] = useState<boolean>(false)
 
@@ -174,12 +159,7 @@ const Container: React.FC<Props> = (props) => {
       if (!layout) {
         return
       }
-      dispatch(
-        saveLayout({
-          ...layout,
-          elements: [...layout.elements, createLayoutElement(type)],
-        }),
-      )
+      dispatch(saveLayout(addElement(layout, createLayoutElement(type))))
     },
     [dispatch, layout],
   )
@@ -192,6 +172,7 @@ const Container: React.FC<Props> = (props) => {
         onReorder,
         onPressElement,
         onPressAdd,
+        onPressFields,
         isPickerVisible,
         onSelectElementType,
         onCancelPicker,

--- a/src/screens/LayoutFields/index.tsx
+++ b/src/screens/LayoutFields/index.tsx
@@ -1,0 +1,243 @@
+import {
+  type RouteProp,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native'
+import type React from 'react'
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  useColorScheme,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import AlertAsync from 'react-native-alert-async'
+import { makeStyles } from 'react-native-swag-styles'
+import { useDispatch, useSelector } from 'react-redux'
+import { COLOR, MESSAGE } from '@/CONSTANTS'
+import { InputDialog } from '@/components/Dialog'
+import { Cell, Section } from '@/components/List'
+import type { Layout, LayoutField } from '@/print'
+import {
+  createLayoutField,
+  isFieldReferenced,
+  removeField,
+  upsertField,
+} from '@/print'
+import { selectLayoutById } from '@/redux/modules/layout/selectors'
+import { saveLayout } from '@/redux/modules/layout/slice'
+import type { MainParams } from '@/routes/main.params'
+import { styleType } from '@/utils/styles'
+import { fieldValueTypeItems } from '../ElementEditor/options'
+import { PickerCell, TextValueCell } from '../ElementEditor/rows'
+
+type ParamsProps = RouteProp<MainParams, 'LayoutFields'>
+
+type Props = {}
+type ComponentProps = Props & {
+  layout: Layout | undefined
+  isDialogVisible: boolean
+  onChangeField: (field: LayoutField) => void
+  onDeleteField: (field: LayoutField) => void
+  onPressAdd: () => void
+  onSubmitLabel: (label: string) => void
+  onCancelDialog: () => void
+}
+
+const Component: React.FC<ComponentProps> = ({
+  layout,
+  isDialogVisible,
+  onChangeField,
+  onDeleteField,
+  onPressAdd,
+  onSubmitLabel,
+  onCancelDialog,
+}) => {
+  const styles = useStyles()
+
+  if (!layout) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>レイアウトが見つかりません</Text>
+      </View>
+    )
+  }
+
+  return (
+    <>
+      <ScrollView style={styles.scrollView}>
+        <Text style={styles.description}>
+          差し込み口は、印刷データごとに内容を変えたい箇所です。要素の「内容の決め方」で
+          「印刷データから差し込む」を選ぶと、ここで作った差し込み口を指定できます。
+        </Text>
+        {layout.fields.length === 0 ? (
+          <Section title="差し込み口">
+            <Cell
+              title="差し込み口がありません"
+              description="下の「差し込み口を追加する」から作成してください"
+              inactive={true}
+            />
+          </Section>
+        ) : (
+          layout.fields.map((field) => (
+            <Section key={field.id} title={field.label || field.key}>
+              <TextValueCell
+                title="表示名"
+                value={field.label}
+                onChange={(label) => onChangeField({ ...field, label })}
+              />
+              <TextValueCell
+                title="キー"
+                value={field.key}
+                dialogDescription="印刷データと結びつける識別子です"
+                onChange={(key) => onChangeField({ ...field, key })}
+              />
+              <PickerCell
+                title="入力の種類"
+                value={field.valueType}
+                items={fieldValueTypeItems}
+                onChange={(valueType) => onChangeField({ ...field, valueType })}
+              />
+              <Cell
+                title="この差し込み口を削除する"
+                onPress={() => onDeleteField(field)}
+              />
+            </Section>
+          ))
+        )}
+        <Section title="操作">
+          <Cell title="差し込み口を追加する" onPress={onPressAdd} />
+        </Section>
+      </ScrollView>
+      <InputDialog
+        isVisible={isDialogVisible}
+        title="差し込み口の追加"
+        description="表示名を入力してください"
+        onPress={onSubmitLabel}
+        onCancel={onCancelDialog}
+      />
+    </>
+  )
+}
+
+const Container: React.FC<Props> = (props) => {
+  const navigation = useNavigation()
+  const dispatch = useDispatch()
+
+  const {
+    params: { layoutId },
+  } = useRoute<ParamsProps>()
+
+  const selector = useMemo(() => selectLayoutById(layoutId), [layoutId])
+  const layout = useSelector(selector)
+
+  const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: '差し込み口' })
+  }, [navigation])
+
+  const onChangeField = useCallback(
+    (field: LayoutField) => {
+      if (!layout) {
+        return
+      }
+      dispatch(saveLayout(upsertField(layout, field)))
+    },
+    [dispatch, layout],
+  )
+
+  const onDeleteField = useCallback(
+    async (field: LayoutField) => {
+      if (!layout) {
+        return
+      }
+      try {
+        const referenced = isFieldReferenced(layout, field.id)
+        const confirmed = await AlertAsync(
+          '確認',
+          referenced
+            ? `「${field.label || field.key}」を削除しますか？\nこの差し込み口を使っている要素は、内容が空の固定値に戻ります。`
+            : `「${field.label || field.key}」を削除しますか？`,
+          [
+            { text: MESSAGE.NO, onPress: () => false, style: 'cancel' },
+            { text: MESSAGE.YES, onPress: () => true },
+          ],
+        )
+        if (confirmed) {
+          dispatch(saveLayout(removeField(layout, field.id)))
+        }
+      } catch (e: any) {
+        console.warn('onDeleteField', e)
+      }
+    },
+    [dispatch, layout],
+  )
+
+  const onPressAdd = useCallback(() => setIsDialogVisible(true), [])
+  const onCancelDialog = useCallback(() => setIsDialogVisible(false), [])
+
+  const onSubmitLabel = useCallback(
+    (label: string) => {
+      setIsDialogVisible(false)
+      if (!layout) {
+        return
+      }
+      const trimmed = label.trim()
+      dispatch(
+        saveLayout(
+          upsertField(
+            layout,
+            createLayoutField({
+              label: trimmed || '差し込み口',
+              key: trimmed || `field${layout.fields.length + 1}`,
+            }),
+          ),
+        ),
+      )
+    },
+    [dispatch, layout],
+  )
+
+  return (
+    <Component
+      {...props}
+      {...{
+        layout,
+        isDialogVisible,
+        onChangeField,
+        onDeleteField,
+        onPressAdd,
+        onSubmitLabel,
+        onCancelDialog,
+      }}
+    />
+  )
+}
+
+export { Container as LayoutFields }
+
+const useStyles = makeStyles(useColorScheme, (colorScheme) => {
+  const styles = StyleSheet.create({
+    scrollView: styleType<ViewStyle>({
+      flex: 1,
+    }),
+    description: styleType<TextStyle>({
+      padding: 16,
+      fontSize: 12,
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+    empty: styleType<ViewStyle>({
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    }),
+    emptyText: styleType<TextStyle>({
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+  })
+  return styles
+})


### PR DESCRIPTION
> [!NOTE]
> [#469](https://github.com/mitsuharu/mobile-printer/pull/469) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

要素ごとの編集画面と、差し込み口（レイアウトのフィールド定義）を編集する画面を追加します。これで**レイアウトを一通り組み立てられる**ようになります。

- `src/print/mutations.ts` … 要素と差し込み口を編集する純粋関数
- `src/screens/ElementEditor/` … 要素ごとの編集画面
- `src/screens/LayoutFields/` … 差し込み口の定義
- `src/components/Modal/ListPickerModal/` … 一覧から選ぶモーダル（共通化）

## 設計

**差し込み口を削除したら、参照していた要素の参照先を必ず外します。** 外さないと壊れた参照が残るため、`removeField` で固定値（画像なら未選択）へ戻します。削除前に `isFieldReferenced` で参照中か調べ、「この差し込み口を使っている要素は、内容が空の固定値に戻ります」と伝えてから確認を取ります。

**編集操作は純粋関数に切り出しました。** 画面は `replaceElement` / `removeElement` / `moveElement` / `upsertField` / `removeField` を呼ぶだけなので、参照の付け替えのような間違えやすい処理をテストで固定できます。

**選択肢は `ListPickerModal` に共通化しました。** PR6a で踏んだ「Android の Alert は3ボタンまで」の制約は、寄せ・線種・誤り訂正レベル・入力の種類など、ほぼすべての選択肢に当てはまるためです。

**数値入力は範囲外や数値でない入力を捨てて元の値を保ちます。** 幅・行数・QRの大きさなど、印刷が成立しない値が入るのを防ぐためです。

要素の削除は編集画面へ移し、一覧のタップは編集画面への遷移になりました（PR6a の暫定仕様の解消）。

## 編集できる項目

| 要素 | 項目 |
| --- | --- |
| テキスト | 供給元、内容、文字の大きさ、寄せ、太字、下線、空なら印刷しない |
| 画像 | 供給元、画像の選択、印刷する幅、変換方法、寄せ、空なら印刷しない |
| QRコード | 供給元、内容、大きさ、誤り訂正レベル、寄せ、空なら印刷しない |
| 列 | 列ごとの供給元・幅・寄せ、列の追加と削除、空なら印刷しない |
| 区切り線 | 線の種類 |
| 空白 | 空ける行数 |
| 印刷時刻 | 書式（定型と直接指定）、寄せ |

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし（警告84件、増分は既存コードと同じ `catch (e: any)` によるもの） |
| `TZ=Asia/Tokyo yarn test --runInBand` | 12 suites / 182 tests 成功（本PRで19件追加） |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

1. 差し込み口を追加し、表示名・キー・入力の種類が編集できる
2. テキスト要素の「内容の決め方」を「印刷データから差し込む」へ変更 → 差し込み口を選べる
3. 端末の `mobile_printer.sqlite` で、要素の `source` が `{"kind":"field","fieldId":"..."}` に更新されることを確認
4. その差し込み口を削除 → 参照中の警告が出る → 削除すると `layout_fields` が0件になり、**要素の `source` が `{"kind":"static","value":""}` へ戻る**ことを確認
5. logcat にクラッシュ・エラーなし

印刷そのものは変更していないため、印刷の確認は行っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
