### PR TITLE
feat(layout): レイアウト編集中の印刷プレビューを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dayjs": "^1.11.23",
     "patch-package": "^8.0.1",
     "postinstall-postinstall": "^2.1.0",
+    "qrcode-generator": "2.0.4",
     "react": "19.2.3",
     "react-hook-form": "^7.87.0",
     "react-native": "0.87.1",

--- a/src/components/PrintPreview/QRCodeView.tsx
+++ b/src/components/PrintPreview/QRCodeView.tsx
@@ -1,0 +1,111 @@
+import qrcode from 'qrcode-generator'
+import type React from 'react'
+import { useMemo } from 'react'
+import { StyleSheet, View, type ViewStyle } from 'react-native'
+import { styleType } from '@/utils/styles'
+
+type Props = {
+  text: string
+  /**
+   * QRコードの1マスの大きさ（印刷時のドット数）
+   */
+  moduleSize: number
+}
+
+type Run = { start: number; length: number }
+
+/**
+ * 1行分の黒いマスを、連続する区間へまとめる
+ *
+ * マスごとに View を置くと数千個になるため、横に連なる部分をまとめて描く。
+ */
+const toRuns = (isDark: (index: number) => boolean, count: number): Run[] => {
+  const runs: Run[] = []
+  let start = -1
+
+  for (let index = 0; index < count; index += 1) {
+    if (isDark(index)) {
+      if (start < 0) {
+        start = index
+      }
+    } else if (start >= 0) {
+      runs.push({ start, length: index - start })
+      start = -1
+    }
+  }
+  if (start >= 0) {
+    runs.push({ start, length: count - start })
+  }
+
+  return runs
+}
+
+/**
+ * プレビュー用のQRコード
+ */
+export const QRCodeView: React.FC<Props> = ({ text, moduleSize }) => {
+  const matrix = useMemo(() => {
+    try {
+      const qr = qrcode(0, 'L')
+      qr.addData(text)
+      qr.make()
+      const count = qr.getModuleCount()
+      return {
+        count,
+        rows: Array.from({ length: count }, (_, row) =>
+          toRuns((column) => qr.isDark(row, column), count),
+        ),
+      }
+    } catch (e: any) {
+      console.warn('QRCodeView', e)
+      return undefined
+    }
+  }, [text])
+
+  if (!matrix) {
+    return null
+  }
+
+  const size = matrix.count * moduleSize
+
+  return (
+    <View style={[styles.container, { width: size, height: size }]}>
+      {matrix.rows.map((runs, row) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: 行番号そのものが位置を表す
+        <View key={row} style={styles.row}>
+          {runs.map((run) => (
+            <View
+              key={`${row}-${run.start}`}
+              style={[
+                styles.module,
+                {
+                  left: run.start * moduleSize,
+                  top: row * moduleSize,
+                  width: run.length * moduleSize,
+                  height: moduleSize,
+                },
+              ]}
+            />
+          ))}
+        </View>
+      ))}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: styleType<ViewStyle>({
+    backgroundColor: 'white',
+  }),
+  row: styleType<ViewStyle>({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  }),
+  module: styleType<ViewStyle>({
+    position: 'absolute',
+    backgroundColor: 'black',
+  }),
+})

--- a/src/components/PrintPreview/__test__/previewData.test.ts
+++ b/src/components/PrintPreview/__test__/previewData.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from '@jest/globals'
+import { buildPrintCommands, type Layout } from '@/print'
+import { createPreviewPrintData } from '../previewData'
+
+const layout: Layout = {
+  id: 'layout-1',
+  name: '名刺',
+  fields: [
+    { id: 'field-1', key: 'name', label: '名前', valueType: 'text' },
+    { id: 'field-2', key: 'icon', label: '', valueType: 'image' },
+  ],
+  elements: [
+    {
+      id: 'text-1',
+      type: 'text',
+      source: { kind: 'field', fieldId: 'field-1' },
+      fontSize: 24,
+      bold: false,
+      underline: false,
+      alignment: 'center',
+      hideWhenEmpty: true,
+    },
+  ],
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+describe('createPreviewPrintData', () => {
+  it('文字の差し込み口へ表示名を仮の値として入れる', () => {
+    expect(createPreviewPrintData(layout).values['field-1']).toEqual({
+      kind: 'text',
+      value: '［名前］',
+    })
+  })
+
+  it('表示名が空ならキーを使う', () => {
+    const value = createPreviewPrintData({
+      ...layout,
+      fields: [{ id: 'field-3', key: 'company', label: '', valueType: 'text' }],
+    }).values['field-3']
+    expect(value).toEqual({ kind: 'text', value: '［company］' })
+  })
+
+  it('画像の差し込み口には仮の値を入れない', () => {
+    expect(createPreviewPrintData(layout).values['field-2']).toBeUndefined()
+  })
+
+  it('仮の値のおかげで、差し込みの要素もプレビューに現れる', () => {
+    const commands = buildPrintCommands(layout, createPreviewPrintData(layout))
+    expect(commands).toContainEqual({ type: 'printText', text: '［名前］' })
+  })
+
+  it('印刷データがなければ差し込みの要素は消える', () => {
+    expect(buildPrintCommands(layout)).toEqual([])
+  })
+})

--- a/src/components/PrintPreview/__test__/rows.test.ts
+++ b/src/components/PrintPreview/__test__/rows.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from '@jest/globals'
+import type { PrintCommand } from '@/print'
+import { buildPreviewRows } from '../rows'
+
+describe('buildPreviewRows', () => {
+  it('操作がなければ行も作らない', () => {
+    expect(buildPreviewRows([])).toEqual([])
+  })
+
+  it('直前に指定された書式でテキストを描く', () => {
+    const commands: PrintCommand[] = [
+      { type: 'setAlignment', alignment: 'right' },
+      { type: 'setFontSize', size: 32 },
+      { type: 'setTextStyle', style: 'bold', enabled: true },
+      { type: 'setTextStyle', style: 'underline', enabled: true },
+      { type: 'printText', text: '江本光晴' },
+    ]
+
+    expect(buildPreviewRows(commands)).toEqual([
+      {
+        type: 'text',
+        text: '江本光晴',
+        fontSize: 32,
+        bold: true,
+        underline: true,
+        alignment: 'right',
+      },
+    ])
+  })
+
+  it('書式の指定は次のテキストへ引き継ぐ', () => {
+    const commands: PrintCommand[] = [
+      { type: 'setFontSize', size: 32 },
+      { type: 'printText', text: 'A' },
+      { type: 'printText', text: 'B' },
+    ]
+
+    const rows = buildPreviewRows(commands)
+    expect(rows.map((row) => row.type === 'text' && row.fontSize)).toEqual([
+      32, 32,
+    ])
+  })
+
+  it('書式の解除も反映する', () => {
+    const commands: PrintCommand[] = [
+      { type: 'setTextStyle', style: 'bold', enabled: true },
+      { type: 'printText', text: 'A' },
+      { type: 'setTextStyle', style: 'bold', enabled: false },
+      { type: 'printText', text: 'B' },
+    ]
+
+    const rows = buildPreviewRows(commands)
+    expect(rows.map((row) => row.type === 'text' && row.bold)).toEqual([
+      true,
+      false,
+    ])
+  })
+
+  it('書式を指定していなければ既定の書式で描く', () => {
+    expect(buildPreviewRows([{ type: 'printText', text: 'A' }])).toEqual([
+      {
+        type: 'text',
+        text: 'A',
+        fontSize: 24,
+        bold: false,
+        underline: false,
+        alignment: 'left',
+      },
+    ])
+  })
+
+  it('画像・QR・列・区切り線・空白を行にする', () => {
+    const commands: PrintCommand[] = [
+      { type: 'setAlignment', alignment: 'center' },
+      { type: 'printImage', base64: 'AAAA', width: 200, imageType: 'binary' },
+      {
+        type: 'printQRCode',
+        text: 'https://example.com/',
+        moduleSize: 8,
+        errorLevel: 'low',
+      },
+      {
+        type: 'printColumns',
+        texts: ['X:', '@mitsuharu_e'],
+        widths: [10, 22],
+        alignments: ['left', 'left'],
+      },
+      { type: 'printHR', barType: 'wave' },
+      { type: 'lineWrap', count: 3 },
+    ]
+
+    expect(buildPreviewRows(commands)).toEqual([
+      {
+        type: 'image',
+        base64: 'AAAA',
+        width: 200,
+        imageType: 'binary',
+        alignment: 'center',
+      },
+      {
+        type: 'qrcode',
+        text: 'https://example.com/',
+        moduleSize: 8,
+        alignment: 'center',
+      },
+      {
+        type: 'columns',
+        texts: ['X:', '@mitsuharu_e'],
+        widths: [10, 22],
+        alignments: ['left', 'left'],
+        fontSize: 24,
+      },
+      { type: 'divider', barType: 'wave' },
+      { type: 'blank', count: 3 },
+    ])
+  })
+})

--- a/src/components/PrintPreview/index.tsx
+++ b/src/components/PrintPreview/index.tsx
@@ -1,0 +1,195 @@
+import type { Alignment } from '@mitsuharu/react-native-sunmi-printer-library'
+import type React from 'react'
+import { useMemo } from 'react'
+import {
+  Image,
+  type ImageStyle,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import { BASE64 } from '@/CONSTANTS'
+import type { PrintCommand } from '@/print'
+import { styleType } from '@/utils/styles'
+import { QRCodeView } from './QRCodeView'
+import { buildPreviewRows, type PreviewRow } from './rows'
+
+export * from './previewData'
+export * from './rows'
+
+type Props = {
+  commands: PrintCommand[]
+  /**
+   * 用紙の印刷可能な幅（ドット）
+   */
+  paperPixelWidth?: number
+}
+
+const barCharacters: Record<string, string> = {
+  line: '─',
+  double: '═',
+  dots: '·',
+  wave: '~',
+  plus: '+',
+  star: '*',
+}
+
+const toFlex = (alignment: Alignment) => {
+  switch (alignment) {
+    case 'left':
+      return 'flex-start'
+    case 'right':
+      return 'flex-end'
+    default:
+      return 'center'
+  }
+}
+
+const toTextAlign = (alignment: Alignment) => alignment
+
+/**
+ * 等幅フォントの1文字の送り幅（フォントサイズに対する比）
+ */
+const MONOSPACE_ADVANCE_RATIO = 0.6
+
+/**
+ * プリンターにおける半角1文字あたりのドット数
+ *
+ * 58mm(384ドット)に既定のフォント(24)で32文字並ぶことから、文字サイズの半分とする。
+ */
+const characterWidth = (printerFontSize: number) => printerFontSize / 2
+
+/**
+ * プリンターの文字サイズを、画面で同じ字送りになるフォントサイズへ換算する
+ *
+ * そのまま同じ数値で描くと、等幅フォントの送り幅の分だけ横に広がり、
+ * 1行に入る文字数が実際の印刷とずれる。
+ */
+const previewFontSize = (printerFontSize: number) =>
+  characterWidth(printerFontSize) / MONOSPACE_ADVANCE_RATIO
+
+const Row: React.FC<{ row: PreviewRow; paperPixelWidth: number }> = ({
+  row,
+  paperPixelWidth,
+}) => {
+  switch (row.type) {
+    case 'text':
+      return (
+        <Text
+          style={[
+            styles.text,
+            {
+              fontSize: previewFontSize(row.fontSize),
+              lineHeight: row.fontSize * 1.2,
+              fontWeight: row.bold ? 'bold' : 'normal',
+              textDecorationLine: row.underline ? 'underline' : 'none',
+              textAlign: toTextAlign(row.alignment),
+            },
+          ]}
+        >
+          {row.text}
+        </Text>
+      )
+    case 'image':
+      return (
+        <View style={{ alignItems: toFlex(row.alignment) }}>
+          <Image
+            source={{ uri: `${BASE64.PREFIX}${row.base64}` }}
+            style={[styles.image, { width: row.width, height: row.width }]}
+            resizeMode="contain"
+          />
+        </View>
+      )
+    case 'qrcode':
+      return (
+        <View style={{ alignItems: toFlex(row.alignment) }}>
+          <QRCodeView text={row.text} moduleSize={row.moduleSize} />
+        </View>
+      )
+    case 'columns':
+      return (
+        <View style={styles.columns}>
+          {row.texts.map((text, index) => (
+            <Text
+              key={`${index}-${text}`}
+              numberOfLines={1}
+              ellipsizeMode="clip"
+              style={[
+                styles.text,
+                {
+                  width:
+                    (row.widths[index] ?? 0) * characterWidth(row.fontSize),
+                  fontSize: previewFontSize(row.fontSize),
+                  lineHeight: row.fontSize * 1.2,
+                  textAlign: toTextAlign(row.alignments[index] ?? 'left'),
+                },
+              ]}
+            >
+              {text}
+            </Text>
+          ))}
+        </View>
+      )
+    case 'divider': {
+      const character = barCharacters[row.barType] ?? '─'
+      // 端まで引ききるよう多めに並べ、はみ出した分は切り落とす
+      const count = Math.ceil(paperPixelWidth / characterWidth(24)) + 2
+      return (
+        <Text
+          numberOfLines={1}
+          ellipsizeMode="clip"
+          style={[styles.text, styles.divider]}
+        >
+          {character.repeat(count)}
+        </Text>
+      )
+    }
+    case 'blank':
+      return <View style={{ height: row.count * 24 * 1.2 }} />
+  }
+}
+
+/**
+ * 印刷結果のプレビュー
+ *
+ * 印刷と同じ `PrintCommand[]` を描き直すため、実際の出力とずれにくい。
+ * 用紙の幅で描いたうえで、画面に収まるよう縮小する。
+ */
+export const PrintPreview: React.FC<Props> = ({
+  commands,
+  paperPixelWidth = BASE64.MAX_SIZE,
+}) => {
+  const rows = useMemo(() => buildPreviewRows(commands), [commands])
+
+  return (
+    <View style={[styles.paper, { width: paperPixelWidth }]}>
+      {rows.map((row, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: 行の位置そのものが並び順を表す
+        <Row key={index} row={row} paperPixelWidth={paperPixelWidth} />
+      ))}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  paper: styleType<ViewStyle>({
+    backgroundColor: 'white',
+    paddingVertical: 8,
+  }),
+  text: styleType<TextStyle>({
+    color: 'black',
+    fontFamily: 'monospace',
+  }),
+  divider: styleType<TextStyle>({
+    fontSize: 20,
+    lineHeight: 24 * 1.2,
+  }),
+  columns: styleType<ViewStyle>({
+    flexDirection: 'row',
+  }),
+  image: styleType<ImageStyle>({
+    resizeMode: 'contain',
+  }),
+})

--- a/src/components/PrintPreview/previewData.ts
+++ b/src/components/PrintPreview/previewData.ts
@@ -1,0 +1,23 @@
+import type { Layout, PrintData } from '@/print'
+
+/**
+ * プレビュー用に、差し込み口へ仮の値を入れた印刷データを作る
+ *
+ * 実際の印刷データがない状態では差し込みが空になり、`hideWhenEmpty` の要素が
+ * すべて消えて体裁を確かめられない。表示名を仮の値として入れておく。
+ */
+export const createPreviewPrintData = (layout: Layout): PrintData => ({
+  id: 'preview',
+  layoutId: layout.id,
+  title: 'プレビュー',
+  values: Object.fromEntries(
+    layout.fields
+      .filter(({ valueType }) => valueType !== 'image')
+      .map((field) => [
+        field.id,
+        { kind: 'text' as const, value: `［${field.label || field.key}］` },
+      ]),
+  ),
+  createdAt: 0,
+  updatedAt: 0,
+})

--- a/src/components/PrintPreview/rows.ts
+++ b/src/components/PrintPreview/rows.ts
@@ -1,0 +1,127 @@
+import type {
+  Alignment,
+  BarType,
+  PrintImageType,
+} from '@mitsuharu/react-native-sunmi-printer-library'
+import { FONT_SIZE } from '@/CONSTANTS'
+import type { PrintCommand } from '@/print'
+
+export type PreviewRow =
+  | {
+      type: 'text'
+      text: string
+      fontSize: number
+      bold: boolean
+      underline: boolean
+      alignment: Alignment
+    }
+  | {
+      type: 'image'
+      base64: string
+      width: number
+      imageType: PrintImageType
+      alignment: Alignment
+    }
+  | {
+      type: 'qrcode'
+      text: string
+      moduleSize: number
+      alignment: Alignment
+    }
+  | {
+      type: 'columns'
+      texts: string[]
+      widths: number[]
+      alignments: Alignment[]
+      fontSize: number
+    }
+  | { type: 'divider'; barType: BarType }
+  | { type: 'blank'; count: number }
+
+type PrintStyle = {
+  alignment: Alignment
+  fontSize: number
+  bold: boolean
+  underline: boolean
+}
+
+const initialStyle: PrintStyle = {
+  alignment: 'left',
+  fontSize: FONT_SIZE.DEFAULT,
+  bold: false,
+  underline: false,
+}
+
+/**
+ * プリンターへ送る操作を、画面に描ける行へ組み直す
+ *
+ * 印刷と同じ `PrintCommand[]` を入力にしているため、プレビューと実際の印刷が
+ * 同じ解釈を共有する。
+ */
+export const buildPreviewRows = (commands: PrintCommand[]): PreviewRow[] => {
+  const style = { ...initialStyle }
+  const rows: PreviewRow[] = []
+
+  for (const command of commands) {
+    switch (command.type) {
+      case 'setAlignment':
+        style.alignment = command.alignment
+        break
+      case 'setFontSize':
+        style.fontSize = command.size
+        break
+      case 'setTextStyle':
+        if (command.style === 'bold') {
+          style.bold = command.enabled
+        }
+        if (command.style === 'underline') {
+          style.underline = command.enabled
+        }
+        break
+      case 'printText':
+        rows.push({
+          type: 'text',
+          text: command.text,
+          fontSize: style.fontSize,
+          bold: style.bold,
+          underline: style.underline,
+          alignment: style.alignment,
+        })
+        break
+      case 'printImage':
+        rows.push({
+          type: 'image',
+          base64: command.base64,
+          width: command.width,
+          imageType: command.imageType,
+          alignment: style.alignment,
+        })
+        break
+      case 'printQRCode':
+        rows.push({
+          type: 'qrcode',
+          text: command.text,
+          moduleSize: command.moduleSize,
+          alignment: style.alignment,
+        })
+        break
+      case 'printColumns':
+        rows.push({
+          type: 'columns',
+          texts: command.texts,
+          widths: command.widths,
+          alignments: command.alignments,
+          fontSize: style.fontSize,
+        })
+        break
+      case 'printHR':
+        rows.push({ type: 'divider', barType: command.barType })
+        break
+      case 'lineWrap':
+        rows.push({ type: 'blank', count: command.count })
+        break
+    }
+  }
+
+  return rows
+}

--- a/src/routes/main.constraint.ts
+++ b/src/routes/main.constraint.ts
@@ -6,6 +6,7 @@ export const MainName = {
   LayoutEditor: 'LayoutEditor',
   ElementEditor: 'ElementEditor',
   LayoutFields: 'LayoutFields',
+  LayoutPreview: 'LayoutPreview',
 } as const
 
 export type MainName = (typeof MainName)[keyof typeof MainName]

--- a/src/routes/main.params.ts
+++ b/src/routes/main.params.ts
@@ -8,4 +8,5 @@ export type MainParams = {
   LayoutEditor: { layoutId: string }
   ElementEditor: { layoutId: string; elementId: string }
   LayoutFields: { layoutId: string }
+  LayoutPreview: { layoutId: string }
 }

--- a/src/routes/main.routes.tsx
+++ b/src/routes/main.routes.tsx
@@ -6,6 +6,7 @@ import { Home } from '@/screens/Home'
 import { LayoutEditor } from '@/screens/LayoutEditor'
 import { LayoutFields } from '@/screens/LayoutFields'
 import { LayoutList } from '@/screens/LayoutList'
+import { LayoutPreview } from '@/screens/LayoutPreview'
 import { Printer } from '@/screens/Printer'
 import { MainName } from './main.constraint'
 import type { MainParams } from './main.params'
@@ -27,6 +28,7 @@ const Routes: React.FC = () => {
       <Stack.Screen name={MainName.LayoutEditor} component={LayoutEditor} />
       <Stack.Screen name={MainName.ElementEditor} component={ElementEditor} />
       <Stack.Screen name={MainName.LayoutFields} component={LayoutFields} />
+      <Stack.Screen name={MainName.LayoutPreview} component={LayoutPreview} />
     </Stack.Navigator>
   )
 }

--- a/src/screens/LayoutEditor/index.tsx
+++ b/src/screens/LayoutEditor/index.tsx
@@ -39,6 +39,7 @@ type ComponentProps = Props & {
   onPressElement: (element: LayoutElement) => void
   onPressAdd: () => void
   onPressFields: () => void
+  onPressPreview: () => void
   isPickerVisible: boolean
   onSelectElementType: (type: LayoutElementType) => void
   onCancelPicker: () => void
@@ -50,6 +51,7 @@ const Component: React.FC<ComponentProps> = ({
   onPressElement,
   onPressAdd,
   onPressFields,
+  onPressPreview,
   isPickerVisible,
   onSelectElementType,
   onCancelPicker,
@@ -92,6 +94,11 @@ const Component: React.FC<ComponentProps> = ({
           title="差し込み口"
           description={`${layout.fields.length}個`}
           onPress={onPressFields}
+          accessory="disclosure"
+        />
+        <Cell
+          title="印刷イメージを見る"
+          onPress={onPressPreview}
           accessory="disclosure"
         />
       </Section>
@@ -143,6 +150,10 @@ const Container: React.FC<Props> = (props) => {
     navigation.navigate('LayoutFields', { layoutId })
   }, [navigation, layoutId])
 
+  const onPressPreview = useCallback(() => {
+    navigation.navigate('LayoutPreview', { layoutId })
+  }, [navigation, layoutId])
+
   const [isPickerVisible, setIsPickerVisible] = useState<boolean>(false)
 
   const onPressAdd = useCallback(() => {
@@ -173,6 +184,7 @@ const Container: React.FC<Props> = (props) => {
         onPressElement,
         onPressAdd,
         onPressFields,
+        onPressPreview,
         isPickerVisible,
         onSelectElementType,
         onCancelPicker,

--- a/src/screens/LayoutPreview/index.tsx
+++ b/src/screens/LayoutPreview/index.tsx
@@ -1,0 +1,164 @@
+import {
+  type RouteProp,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native'
+import type React from 'react'
+import { useLayoutEffect, useMemo, useState } from 'react'
+import {
+  type LayoutChangeEvent,
+  ScrollView,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  useColorScheme,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import { makeStyles } from 'react-native-swag-styles'
+import { useSelector } from 'react-redux'
+import { BASE64, COLOR } from '@/CONSTANTS'
+import { createPreviewPrintData, PrintPreview } from '@/components/PrintPreview'
+import type { Layout, PrintCommand } from '@/print'
+import { buildPrintCommands } from '@/print'
+import { selectLayoutById } from '@/redux/modules/layout/selectors'
+import { selectPrinterInfo } from '@/redux/modules/printer/selectors'
+import type { MainParams } from '@/routes/main.params'
+import { styleType } from '@/utils/styles'
+
+type ParamsProps = RouteProp<MainParams, 'LayoutPreview'>
+
+/**
+ * プレビューの左右の余白
+ */
+const HORIZONTAL_PADDING = 16
+
+type Props = {}
+type ComponentProps = Props & {
+  layout: Layout | undefined
+  commands: PrintCommand[]
+  paperPixelWidth: number
+  scale: number
+  onLayout: (event: LayoutChangeEvent) => void
+}
+
+const Component: React.FC<ComponentProps> = ({
+  layout,
+  commands,
+  paperPixelWidth,
+  scale,
+  onLayout,
+}) => {
+  const styles = useStyles()
+
+  if (!layout) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>レイアウトが見つかりません</Text>
+      </View>
+    )
+  }
+
+  return (
+    <View style={styles.container} onLayout={onLayout}>
+      <Text style={styles.description}>
+        用紙の幅 {paperPixelWidth}px
+        で描いています。差し込み口は表示名を仮の値として入れています。
+      </Text>
+      <ScrollView contentContainerStyle={styles.contentContainer}>
+        {commands.length === 0 ? (
+          <Text style={styles.emptyText}>印刷される内容がありません</Text>
+        ) : (
+          <View
+            style={{
+              width: paperPixelWidth * scale,
+              // 縮小したぶん高さが余るため、原点を左上に固定して詰める
+              transform: [{ scale }],
+              transformOrigin: 'top left',
+            }}
+          >
+            <PrintPreview
+              commands={commands}
+              paperPixelWidth={paperPixelWidth}
+            />
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  )
+}
+
+const Container: React.FC<Props> = (props) => {
+  const navigation = useNavigation()
+
+  const {
+    params: { layoutId },
+  } = useRoute<ParamsProps>()
+
+  const selector = useMemo(() => selectLayoutById(layoutId), [layoutId])
+  const layout = useSelector(selector)
+  const printerInfo = useSelector(selectPrinterInfo)
+
+  const paperPixelWidth = printerInfo?.pixelWidth ?? BASE64.MAX_SIZE
+
+  const [availableWidth, setAvailableWidth] = useState<number>(0)
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: 'プレビュー' })
+  }, [navigation])
+
+  const commands = useMemo(() => {
+    if (!layout) {
+      return []
+    }
+    return buildPrintCommands(layout, createPreviewPrintData(layout))
+  }, [layout])
+
+  const scale = useMemo(() => {
+    const usable = availableWidth - HORIZONTAL_PADDING * 2
+    if (usable <= 0) {
+      return 1
+    }
+    return Math.min(1, usable / paperPixelWidth)
+  }, [availableWidth, paperPixelWidth])
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    setAvailableWidth(event.nativeEvent.layout.width)
+  }
+
+  return (
+    <Component
+      {...props}
+      {...{ layout, commands, paperPixelWidth, scale, onLayout }}
+    />
+  )
+}
+
+export { Container as LayoutPreview }
+
+const useStyles = makeStyles(useColorScheme, (colorScheme) => {
+  const styles = StyleSheet.create({
+    container: styleType<ViewStyle>({
+      flex: 1,
+    }),
+    contentContainer: styleType<ViewStyle>({
+      padding: HORIZONTAL_PADDING,
+      alignItems: 'flex-start',
+    }),
+    description: styleType<TextStyle>({
+      paddingHorizontal: HORIZONTAL_PADDING,
+      paddingTop: 12,
+      fontSize: 12,
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+    empty: styleType<ViewStyle>({
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    }),
+    emptyText: styleType<TextStyle>({
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+  })
+  return styles
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8925,6 +8925,7 @@ __metadata:
     mockdate: "npm:^3.0.5"
     patch-package: "npm:^8.0.1"
     postinstall-postinstall: "npm:^2.1.0"
+    qrcode-generator: "npm:2.0.4"
     react: "npm:19.2.3"
     react-hook-form: "npm:^7.87.0"
     react-native: "npm:0.87.1"
@@ -9602,6 +9603,13 @@ __metadata:
   version: 7.0.1
   resolution: "pure-rand@npm:7.0.1"
   checksum: 10c0/9cade41030f5ec95f5d55a11a71404cd6f46b69becaad892097cd7f58e2c6248cd0a933349ca7d21336ab629f1da42ffe899699b671bc4651600eaf6e57f837e
+  languageName: node
+  linkType: hard
+
+"qrcode-generator@npm:2.0.4":
+  version: 2.0.4
+  resolution: "qrcode-generator@npm:2.0.4"
+  checksum: 10c0/52dc3894bda6afecf09cb36aba9c181f3c4641fcbeac40c2af05d68da1383e3a1c7354bd3dc8c5e2a199d2e62314bbdec8cb4fbbd00bcfda40de56bb36bfdb17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> [!NOTE]
> [#470](https://github.com/mitsuharu/mobile-printer/pull/470) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

レイアウト編集画面から印刷イメージを確認できるようにします。ご要望を受けて計画へ追加した 6c です。

- `src/components/PrintPreview/` … `PrintCommand[]` を画面へ描き直す
- `src/screens/LayoutPreview/` … プレビュー画面
- レイアウト編集画面に「印刷イメージを見る」を追加

## 設計

**印刷とプレビューで同じ `PrintCommand[]` を使います。** レイアウトの解釈をレンダラに切り出してあるので、プレビューは同じ命令列を画面へ描き直すだけです。印刷経路と解釈が分岐しないため、実際の出力とずれにくくなります。

**QRコードは実物を描きます。** 依存のない純JSの `qrcode-generator@2.0.4` を追加しました。マスごとに `View` を置くと数千個になるため、横に連なる黒マスを1つの `View` にまとめています。

**プリンターの文字サイズは、画面で同じ字送りになるフォントサイズへ換算します。** プリンターは58mm(384ドット)に既定フォントで半角32文字が並びますが、同じ数値でそのまま描くと等幅フォントの送り幅の分だけ横に広がり、1行に入る文字数が実際の印刷とずれます。**実機で最初に確認したときは、この換算がないために区切り線が用紙幅からはみ出して「…」で省略されていました。**

**差し込み口には表示名を仮の値として入れます。** 印刷データがない状態では差し込みが空になり、`hideWhenEmpty` の要素がすべて消えて体裁を確かめられないためです。

用紙幅は接続中のプリンターがあれば `PrinterInfo.pixelWidth` を使い、なければ 384px とします。80mm 端末にもそのまま対応します。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし（警告88件、増分は既存コードと同じ `catch (e: any)` によるもの） |
| `TZ=Asia/Tokyo yarn test --runInBand` | 14 suites / 193 tests 成功（本PRで11件追加） |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

テキスト（差し込み・固定）・区切り線（実線と波線）・列・QRコード・空白・印刷時刻を並べたレイアウトで確認しました。

- 各要素が並び順どおりに、指定した寄せと文字サイズで描かれる
- 区切り線が用紙の端まで引かれ、はみ出しや省略がない
- QRコードが実際に読み取れるコードとして描かれる
- 差し込み口が `［名前］` `［X］` の仮の値で表示される
- 用紙幅384pxで描いたものが画面幅に収まるよう縮小される

印刷経路は変更していないため、実際の印刷との突き合わせは PR8 で行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
