### PR TITLE
feat(printData): 印刷データのCRUDと動的フォームを追加

### DIFF
--- a/src/database/repositories/__test__/printDataRepository.test.ts
+++ b/src/database/repositories/__test__/printDataRepository.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it } from '@jest/globals'
+import type { ImageAsset, Layout, PrintData } from '@/print'
+import {
+  createMigratedTestConnection,
+  type TestConnection,
+} from '../../__test__/testConnection'
+import { saveLayout } from '../layoutRepository'
+import {
+  deletePrintData,
+  findAllPrintData,
+  findPrintDataByLayoutId,
+  savePrintData,
+} from '../printDataRepository'
+
+const asset: ImageAsset = {
+  id: 'asset-1',
+  base64: 'AAAA',
+  width: 200,
+  imageType: 'binary',
+}
+
+const layout: Layout = {
+  id: 'layout-1',
+  name: '名刺',
+  fields: [
+    { id: 'field-1', key: 'name', label: '名前', valueType: 'text' },
+    { id: 'field-2', key: 'icon', label: 'アイコン', valueType: 'image' },
+  ],
+  elements: [],
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+const printData: PrintData = {
+  id: 'print-1',
+  layoutId: layout.id,
+  title: '織田信長',
+  values: {
+    'field-1': { kind: 'text', value: '織田信長' },
+    'field-2': { kind: 'image', asset },
+  },
+  createdAt: 100,
+  updatedAt: 100,
+}
+
+let db: TestConnection
+
+beforeEach(async () => {
+  db = await createMigratedTestConnection()
+  await saveLayout(db, layout)
+})
+
+describe('savePrintData / findPrintDataByLayoutId', () => {
+  it('文字と画像の値を読み戻せる', async () => {
+    await savePrintData(db, printData)
+
+    const [loaded] = await findPrintDataByLayoutId(db, layout.id)
+
+    expect(loaded.values).toEqual(printData.values)
+  })
+
+  it('保存し直すと updatedAt が進み、createdAt は残る', async () => {
+    const saved = await savePrintData(db, { ...printData, updatedAt: 0 })
+
+    expect(saved.createdAt).toBe(100)
+    expect(saved.updatedAt).toBeGreaterThan(100)
+  })
+
+  it('保存し直したときに値が重複しない', async () => {
+    await savePrintData(db, printData)
+    await savePrintData(db, {
+      ...printData,
+      values: { 'field-1': { kind: 'text', value: '豊臣秀吉' } },
+    })
+
+    const [loaded] = await findPrintDataByLayoutId(db, layout.id)
+
+    expect(loaded.values).toEqual({
+      'field-1': { kind: 'text', value: '豊臣秀吉' },
+    })
+  })
+
+  it('値が未設定のフィールドは保存しない', async () => {
+    await savePrintData(db, {
+      ...printData,
+      values: { 'field-1': undefined, 'field-2': undefined },
+    })
+
+    const rows = await db.execute('SELECT * FROM print_data_values')
+    expect(rows.rows).toEqual([])
+  })
+
+  it('空文字も値として保存する', async () => {
+    await savePrintData(db, {
+      ...printData,
+      values: { 'field-1': { kind: 'text', value: '' } },
+    })
+
+    const [loaded] = await findPrintDataByLayoutId(db, layout.id)
+    expect(loaded.values['field-1']).toEqual({ kind: 'text', value: '' })
+  })
+
+  it('ほかのレイアウトの印刷データは返さない', async () => {
+    await saveLayout(db, { ...layout, id: 'layout-2', fields: [] })
+    await savePrintData(db, printData)
+    await savePrintData(db, {
+      ...printData,
+      id: 'print-2',
+      layoutId: 'layout-2',
+      values: {},
+    })
+
+    const loaded = await findPrintDataByLayoutId(db, layout.id)
+    expect(loaded.map(({ id }) => id)).toEqual(['print-1'])
+  })
+
+  it('更新が新しい順に並べる', async () => {
+    await savePrintData(db, printData)
+    await db.execute('UPDATE print_data SET updated_at = ? WHERE id = ?', [
+      1,
+      'print-1',
+    ])
+    await savePrintData(db, { ...printData, id: 'print-2', values: {} })
+
+    const loaded = await findAllPrintData(db)
+    expect(loaded.map(({ id }) => id)).toEqual(['print-2', 'print-1'])
+  })
+})
+
+describe('deletePrintData', () => {
+  it('印刷データと、紐づく値をまとめて消す', async () => {
+    await savePrintData(db, printData)
+    await deletePrintData(db, printData.id)
+
+    await expect(findAllPrintData(db)).resolves.toEqual([])
+    const values = await db.execute('SELECT * FROM print_data_values')
+    expect(values.rows).toEqual([])
+  })
+})
+
+describe('レイアウトとの関係', () => {
+  it('レイアウトを消すと印刷データも消える', async () => {
+    await savePrintData(db, printData)
+
+    await db.execute('DELETE FROM layouts WHERE id = ?', [layout.id])
+
+    await expect(findAllPrintData(db)).resolves.toEqual([])
+  })
+
+  it('レイアウトを保存し直しても、残した差し込み口の値は消えない', async () => {
+    await savePrintData(db, printData)
+
+    // 名前を変えただけで、差し込み口は消していない
+    await saveLayout(db, { ...layout, name: '名刺2' })
+
+    const [loaded] = await findAllPrintData(db)
+    expect(loaded.values).toEqual(printData.values)
+  })
+
+  it('差し込み口を編集しても値は消えない', async () => {
+    await savePrintData(db, printData)
+
+    await saveLayout(db, {
+      ...layout,
+      fields: [{ ...layout.fields[0], label: '氏名' }, layout.fields[1]],
+    })
+
+    const [loaded] = await findAllPrintData(db)
+    expect(loaded.values).toEqual(printData.values)
+  })
+
+  it('差し込み口の並び順を入れ替えても値は消えない', async () => {
+    await savePrintData(db, printData)
+
+    await saveLayout(db, {
+      ...layout,
+      fields: [layout.fields[1], layout.fields[0]],
+    })
+
+    const [loaded] = await findAllPrintData(db)
+    expect(loaded.values).toEqual(printData.values)
+  })
+
+  it('差し込み口を消すと、その値も消える', async () => {
+    await savePrintData(db, printData)
+
+    await saveLayout(db, { ...layout, fields: [layout.fields[1]] })
+
+    const [loaded] = await findAllPrintData(db)
+    expect(loaded.values).toEqual({ 'field-2': { kind: 'image', asset } })
+  })
+})

--- a/src/database/repositories/index.ts
+++ b/src/database/repositories/index.ts
@@ -1,3 +1,4 @@
 export * from './imageAssetRepository'
 export * from './layoutRepository'
+export * from './printDataRepository'
 export * from './serializer'

--- a/src/database/repositories/layoutRepository.ts
+++ b/src/database/repositories/layoutRepository.ts
@@ -142,18 +142,32 @@ export const saveLayout = async (
       }
     }
 
+    // 要素は参照されていないため、まとめて入れ替える
     await tx.execute('DELETE FROM layout_elements WHERE layout_id = ?', [
       layout.id,
     ])
-    await tx.execute('DELETE FROM layout_fields WHERE layout_id = ?', [
-      layout.id,
-    ])
+
+    // 差し込み口は印刷データの値から参照されている。まとめて消すと、
+    // 残す差し込み口の値まで連鎖削除されるため、無くなったものだけを消す
+    const fieldIds = layout.fields.map(({ id }) => id)
+    const placeholders = fieldIds.map(() => '?').join(', ')
+    await tx.execute(
+      `DELETE FROM layout_fields
+       WHERE layout_id = ?
+       ${fieldIds.length ? `AND id NOT IN (${placeholders})` : ''}`,
+      [layout.id, ...fieldIds],
+    )
 
     for (const [index, field] of layout.fields.entries()) {
       const row = serializeField(field, layout.id, index)
       await tx.execute(
         `INSERT INTO layout_fields (id, layout_id, key, label, value_type, sort_order)
-         VALUES (?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           key = excluded.key,
+           label = excluded.label,
+           value_type = excluded.value_type,
+           sort_order = excluded.sort_order`,
         [
           row.id,
           row.layout_id,

--- a/src/database/repositories/printDataRepository.ts
+++ b/src/database/repositories/printDataRepository.ts
@@ -1,0 +1,168 @@
+import dayjs from 'dayjs'
+import type { ImageAsset, PrintData, PrintDataValue } from '@/print'
+import type { SqliteConnection } from '../types'
+import { findImageAssets, saveImageAsset } from './imageAssetRepository'
+
+type PrintDataRow = {
+  id: string
+  layout_id: string
+  title: string
+  created_at: number
+  updated_at: number
+}
+
+type PrintDataValueRow = {
+  print_data_id: string
+  field_id: string
+  text_value: string | null
+  asset_id: string | null
+}
+
+const toValue = (
+  row: PrintDataValueRow,
+  assets: ReadonlyMap<string, ImageAsset>,
+): PrintDataValue | undefined => {
+  if (row.asset_id) {
+    const asset = assets.get(row.asset_id)
+    return asset ? { kind: 'image', asset } : undefined
+  }
+  if (row.text_value !== null) {
+    return { kind: 'text', value: row.text_value }
+  }
+  return undefined
+}
+
+const readPrintData = async (
+  db: SqliteConnection,
+  rows: PrintDataRow[],
+): Promise<PrintData[]> => {
+  if (rows.length === 0) {
+    return []
+  }
+
+  const ids = rows.map(({ id }) => id)
+  const placeholders = ids.map(() => '?').join(', ')
+  const valueResult = await db.execute(
+    `SELECT * FROM print_data_values WHERE print_data_id IN (${placeholders})`,
+    ids,
+  )
+  const valueRows = valueResult.rows as unknown as PrintDataValueRow[]
+
+  const assetIds = [
+    ...new Set(
+      valueRows.flatMap((row) => (row.asset_id ? [row.asset_id] : [])),
+    ),
+  ]
+  const assets = new Map(
+    (await findImageAssets(db, assetIds)).map((asset) => [asset.id, asset]),
+  )
+
+  return rows.map((row) => ({
+    id: row.id,
+    layoutId: row.layout_id,
+    title: row.title,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    values: Object.fromEntries(
+      valueRows
+        .filter((value) => value.print_data_id === row.id)
+        .map((value) => [value.field_id, toValue(value, assets)]),
+    ),
+  }))
+}
+
+/**
+ * レイアウトに紐づく印刷データを、新しく更新されたものから順に読む
+ */
+export const findPrintDataByLayoutId = async (
+  db: SqliteConnection,
+  layoutId: string,
+): Promise<PrintData[]> => {
+  const result = await db.execute(
+    'SELECT * FROM print_data WHERE layout_id = ? ORDER BY updated_at DESC',
+    [layoutId],
+  )
+  return readPrintData(db, result.rows as unknown as PrintDataRow[])
+}
+
+/**
+ * すべての印刷データを、新しく更新されたものから順に読む
+ */
+export const findAllPrintData = async (
+  db: SqliteConnection,
+): Promise<PrintData[]> => {
+  const result = await db.execute(
+    'SELECT * FROM print_data ORDER BY updated_at DESC',
+  )
+  return readPrintData(db, result.rows as unknown as PrintDataRow[])
+}
+
+/**
+ * 印刷データを保存する
+ *
+ * 値は入れ替えるため、いったん削除してから入れ直す。
+ */
+export const savePrintData = async (
+  db: SqliteConnection,
+  printData: PrintData,
+): Promise<PrintData> => {
+  const updatedAt = dayjs().valueOf()
+
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      `INSERT INTO print_data (id, layout_id, title, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         title = excluded.title,
+         updated_at = excluded.updated_at`,
+      [
+        printData.id,
+        printData.layoutId,
+        printData.title,
+        printData.createdAt,
+        updatedAt,
+      ],
+    )
+
+    // 画像は値より先に入れる
+    for (const value of Object.values(printData.values)) {
+      if (value?.kind === 'image') {
+        await saveImageAsset(tx, value.asset, updatedAt)
+      }
+    }
+
+    await tx.execute('DELETE FROM print_data_values WHERE print_data_id = ?', [
+      printData.id,
+    ])
+
+    for (const [fieldId, value] of Object.entries(printData.values)) {
+      if (!value) {
+        continue
+      }
+      await tx.execute(
+        `INSERT INTO print_data_values (print_data_id, field_id, text_value, asset_id)
+         VALUES (?, ?, ?, ?)`,
+        [
+          printData.id,
+          fieldId,
+          value.kind === 'text' ? value.value : null,
+          value.kind === 'image' ? value.asset.id : null,
+        ],
+      )
+    }
+  })
+
+  return { ...printData, updatedAt }
+}
+
+/**
+ * 印刷データを削除する
+ *
+ * 値は外部キーの連鎖削除で消える。
+ */
+export const deletePrintData = async (
+  db: SqliteConnection,
+  id: string,
+): Promise<void> => {
+  await db.execute('DELETE FROM print_data WHERE id = ?', [id])
+}

--- a/src/redux/RootState.ts
+++ b/src/redux/RootState.ts
@@ -2,6 +2,7 @@ import type { AsciiArtState } from './modules/asciiArt/slice'
 import type { DatabaseState } from './modules/database/slice'
 import type { LayoutState } from './modules/layout/slice'
 import type { NfcState } from './modules/nfc/slice'
+import type { PrintDataState } from './modules/printData/slice'
 import type { PrinterState } from './modules/printer/slice'
 import type { SnackbarState } from './modules/snackbar/slice'
 import type { UserSettingState } from './modules/userSetting/slice'
@@ -9,6 +10,7 @@ import type { UserSettingState } from './modules/userSetting/slice'
 export interface RootState {
   database: DatabaseState
   layout: LayoutState
+  printData: PrintDataState
   printer: PrinterState
   snackbar: SnackbarState
   userSetting: UserSettingState

--- a/src/redux/index.ts
+++ b/src/redux/index.ts
@@ -7,6 +7,7 @@ import { AsciiArtReducer } from './modules/asciiArt/slice'
 import { databaseReducer } from './modules/database/slice'
 import { layoutReducer } from './modules/layout/slice'
 import { NFCReducer } from './modules/nfc/slice'
+import { printDataReducer } from './modules/printData/slice'
 import { printerReducer } from './modules/printer/slice'
 import { snackbarReducer } from './modules/snackbar/slice'
 import { userSettingReducer } from './modules/userSetting/slice'
@@ -26,6 +27,7 @@ export function initializeRedux() {
     const reducer = combineReducers({
       database: databaseReducer,
       layout: layoutReducer,
+      printData: printDataReducer,
       printer: printerReducer,
       snackbar: snackbarReducer,
       userSetting: userSettingReducer,

--- a/src/redux/modules/printData/saga/__test__/printDataSaga.test.ts
+++ b/src/redux/modules/printData/saga/__test__/printDataSaga.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import { call } from 'redux-saga/effects'
+import { expectSaga } from 'redux-saga-test-plan'
+import type { StaticProvider } from 'redux-saga-test-plan/providers'
+import * as database from '@/database'
+import type { PrintData } from '@/print'
+import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
+import {
+  assignIsLoading,
+  assignPrintData,
+  deletePrintData,
+  duplicatePrintData,
+  fetchPrintData,
+  printDataReducer,
+  savePrintData,
+} from '../../slice'
+import { printDataSaga } from '../index'
+
+const printData: PrintData = {
+  id: 'print-1',
+  layoutId: 'layout-1',
+  title: '織田信長',
+  values: { 'field-1': { kind: 'text', value: '織田信長' } },
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+const connection = {} as database.SqliteConnection
+
+const provideDatabase = (
+  values: PrintData[] = [printData],
+): StaticProvider[] => [
+  [call(database.getDatabase), connection],
+  [call(database.findAllPrintData, connection), values],
+]
+
+describe('printDataSaga fetchPrintData', () => {
+  it('SQLite から読んだ印刷データを state へ反映する', () =>
+    expectSaga(printDataSaga)
+      .withReducer(printDataReducer)
+      .provide(provideDatabase())
+      .dispatch(fetchPrintData())
+      .silentRun()
+      .then(({ storeState }) => {
+        expect(storeState.printData).toEqual([printData])
+      }))
+
+  it('読み込みの開始と終了を伝える', () =>
+    expectSaga(printDataSaga)
+      .provide(provideDatabase())
+      .put(assignIsLoading(true))
+      .put(assignIsLoading(false))
+      .dispatch(fetchPrintData())
+      .silentRun())
+
+  it('失敗しても読み込み中のままにしない', () =>
+    expectSaga(printDataSaga)
+      .provide([
+        {
+          call({ fn }, next) {
+            if (fn === database.getDatabase) {
+              throw new Error('failed')
+            }
+            return next()
+          },
+        },
+      ])
+      .put(enqueueSnackbar({ message: '印刷データの読み込みに失敗しました' }))
+      .put(assignIsLoading(false))
+      .dispatch(fetchPrintData())
+      .silentRun())
+})
+
+describe('printDataSaga savePrintData', () => {
+  it('保存してから読み直す', () => {
+    const save = jest.fn()
+    return expectSaga(printDataSaga)
+      .provide([
+        [call(database.getDatabase), connection],
+        {
+          call({ fn, args }, next) {
+            if (fn === database.savePrintData) {
+              save(args[1])
+              return undefined
+            }
+            if (fn === database.findAllPrintData) {
+              return [printData]
+            }
+            return next()
+          },
+        },
+      ])
+      .put(assignPrintData([printData]))
+      .dispatch(savePrintData(printData))
+      .silentRun()
+      .then(() => {
+        expect(save).toHaveBeenCalledWith(printData)
+      })
+  })
+})
+
+describe('printDataSaga duplicatePrintData', () => {
+  it('コピーであることが分かる名前で、別のIDとして保存する', () => {
+    const save = jest.fn()
+    return expectSaga(printDataSaga)
+      .provide([
+        [call(database.getDatabase), connection],
+        {
+          call({ fn, args }, next) {
+            if (fn === database.savePrintData) {
+              save(args[1])
+              return undefined
+            }
+            if (fn === database.findAllPrintData) {
+              return []
+            }
+            return next()
+          },
+        },
+      ])
+      .dispatch(duplicatePrintData(printData))
+      .silentRun()
+      .then(() => {
+        const saved = save.mock.calls[0][0] as PrintData
+        expect(saved.title).toBe('織田信長のコピー')
+        expect(saved.id).not.toBe(printData.id)
+        expect(saved.values).toEqual(printData.values)
+        expect(saved.layoutId).toBe(printData.layoutId)
+      })
+  })
+})
+
+describe('printDataSaga deletePrintData', () => {
+  it('IDを指定して削除してから読み直す', () => {
+    const remove = jest.fn()
+    return expectSaga(printDataSaga)
+      .provide([
+        [call(database.getDatabase), connection],
+        {
+          call({ fn, args }, next) {
+            if (fn === database.deletePrintData) {
+              remove(args[1])
+              return undefined
+            }
+            if (fn === database.findAllPrintData) {
+              return []
+            }
+            return next()
+          },
+        },
+      ])
+      .put(assignPrintData([]))
+      .dispatch(deletePrintData(printData))
+      .silentRun()
+      .then(() => {
+        expect(remove).toHaveBeenCalledWith(printData.id)
+      })
+  })
+})

--- a/src/redux/modules/printData/saga/index.ts
+++ b/src/redux/modules/printData/saga/index.ts
@@ -1,0 +1,88 @@
+import { call, put, takeEvery, takeLeading } from 'redux-saga/effects'
+import {
+  deletePrintData as deletePrintDataFromDatabase,
+  findAllPrintData,
+  getDatabase,
+  type SqliteConnection,
+  savePrintData as savePrintDataToDatabase,
+} from '@/database'
+import type { PrintData } from '@/print'
+import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
+import { createUUID } from '@/utils/uuid'
+import {
+  assignIsLoading,
+  assignPrintData,
+  deletePrintData,
+  duplicatePrintData,
+  fetchPrintData,
+  savePrintData,
+} from '../slice'
+
+export function* printDataSaga() {
+  yield takeLeading(fetchPrintData, fetchPrintDataSaga)
+  yield takeEvery(savePrintData, savePrintDataSaga)
+  yield takeEvery(duplicatePrintData, duplicatePrintDataSaga)
+  yield takeEvery(deletePrintData, deletePrintDataSaga)
+}
+
+/**
+ * SQLite を情報源として、Redux の写しを作り直す
+ */
+function* reloadPrintDataSaga() {
+  const db: SqliteConnection = yield call(getDatabase)
+  const values: PrintData[] = yield call(findAllPrintData, db)
+  yield put(assignPrintData(values))
+}
+
+function* fetchPrintDataSaga() {
+  try {
+    yield put(assignIsLoading(true))
+    yield call(reloadPrintDataSaga)
+  } catch (e: any) {
+    console.warn('fetchPrintDataSaga', e)
+    yield put(
+      enqueueSnackbar({ message: `印刷データの読み込みに失敗しました` }),
+    )
+  } finally {
+    yield put(assignIsLoading(false))
+  }
+}
+
+function* savePrintDataSaga({ payload }: ReturnType<typeof savePrintData>) {
+  try {
+    const db: SqliteConnection = yield call(getDatabase)
+    yield call(savePrintDataToDatabase, db, payload)
+    yield call(reloadPrintDataSaga)
+  } catch (e: any) {
+    console.warn('savePrintDataSaga', e)
+    yield put(enqueueSnackbar({ message: `印刷データの保存に失敗しました` }))
+  }
+}
+
+function* duplicatePrintDataSaga({
+  payload,
+}: ReturnType<typeof duplicatePrintData>) {
+  try {
+    const db: SqliteConnection = yield call(getDatabase)
+    yield call(savePrintDataToDatabase, db, {
+      ...payload,
+      id: createUUID(),
+      title: `${payload.title}のコピー`,
+    })
+    yield call(reloadPrintDataSaga)
+  } catch (e: any) {
+    console.warn('duplicatePrintDataSaga', e)
+    yield put(enqueueSnackbar({ message: `印刷データの複製に失敗しました` }))
+  }
+}
+
+function* deletePrintDataSaga({ payload }: ReturnType<typeof deletePrintData>) {
+  try {
+    const db: SqliteConnection = yield call(getDatabase)
+    yield call(deletePrintDataFromDatabase, db, payload.id)
+    yield call(reloadPrintDataSaga)
+  } catch (e: any) {
+    console.warn('deletePrintDataSaga', e)
+    yield put(enqueueSnackbar({ message: `印刷データの削除に失敗しました` }))
+  }
+}

--- a/src/redux/modules/printData/selectors.ts
+++ b/src/redux/modules/printData/selectors.ts
@@ -1,0 +1,19 @@
+import { createSelector } from 'reselect'
+import type { PrintData } from '@/print'
+import type { RootState } from '@/redux/RootState'
+
+export const selectAllPrintData = (state: RootState): PrintData[] =>
+  state.printData.printData
+
+export const selectPrintDataIsLoading = (state: RootState): boolean =>
+  state.printData.isLoading
+
+export const selectPrintDataByLayoutId = (layoutId: string | undefined) =>
+  createSelector(selectAllPrintData, (values) =>
+    layoutId ? values.filter((value) => value.layoutId === layoutId) : [],
+  )
+
+export const selectPrintDataById = (id: string | undefined) =>
+  createSelector(selectAllPrintData, (values) =>
+    id ? values.find((value) => value.id === id) : undefined,
+  )

--- a/src/redux/modules/printData/slice.ts
+++ b/src/redux/modules/printData/slice.ts
@@ -1,0 +1,51 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { PrintData } from '@/print'
+
+export type PrintDataState = {
+  /**
+   * SQLite から読み込んだ印刷データ（更新が新しい順）
+   *
+   * @note
+   * 情報源は SQLite で、ここは画面へ供給するための写し。
+   * そのため redux-persist の対象にしない。
+   */
+  printData: PrintData[]
+  isLoading: boolean
+}
+
+const initialState: Readonly<PrintDataState> = {
+  printData: [],
+  isLoading: false,
+}
+
+const printDataSlice = createSlice({
+  name: 'PRINT_DATA',
+  initialState,
+  reducers: {
+    fetchPrintData(_state, _action: PayloadAction<void>) {},
+
+    assignIsLoading(state, { payload }: PayloadAction<boolean>) {
+      state.isLoading = payload
+    },
+
+    assignPrintData(state, { payload }: PayloadAction<PrintData[]>) {
+      state.printData = payload
+    },
+
+    savePrintData(_state, _action: PayloadAction<PrintData>) {},
+
+    duplicatePrintData(_state, _action: PayloadAction<PrintData>) {},
+
+    deletePrintData(_state, _action: PayloadAction<PrintData>) {},
+  },
+})
+
+export const {
+  fetchPrintData,
+  assignIsLoading,
+  assignPrintData,
+  savePrintData,
+  duplicatePrintData,
+  deletePrintData,
+} = printDataSlice.actions
+export const printDataReducer = printDataSlice.reducer

--- a/src/redux/saga.ts
+++ b/src/redux/saga.ts
@@ -4,6 +4,7 @@ import { databaseSaga } from './modules/database/saga'
 import { inAppBrowserSaga } from './modules/inAppWebBrowser/saga'
 import { layoutSaga } from './modules/layout/saga'
 import { nfcSaga } from './modules/nfc/saga'
+import { printDataSaga } from './modules/printData/saga'
 import { printerSaga } from './modules/printer/saga'
 
 export function* rootSaga() {
@@ -11,6 +12,7 @@ export function* rootSaga() {
   yield all([
     fork(databaseSaga),
     fork(layoutSaga),
+    fork(printDataSaga),
     fork(inAppBrowserSaga),
     fork(printerSaga),
     fork(nfcSaga),

--- a/src/routes/main.constraint.ts
+++ b/src/routes/main.constraint.ts
@@ -7,6 +7,8 @@ export const MainName = {
   ElementEditor: 'ElementEditor',
   LayoutFields: 'LayoutFields',
   LayoutPreview: 'LayoutPreview',
+  PrintDataList: 'PrintDataList',
+  PrintDataForm: 'PrintDataForm',
 } as const
 
 export type MainName = (typeof MainName)[keyof typeof MainName]

--- a/src/routes/main.params.ts
+++ b/src/routes/main.params.ts
@@ -8,5 +8,7 @@ export type MainParams = {
   LayoutEditor: { layoutId: string }
   ElementEditor: { layoutId: string; elementId: string }
   LayoutFields: { layoutId: string }
-  LayoutPreview: { layoutId: string }
+  LayoutPreview: { layoutId: string; printDataId?: string }
+  PrintDataList: { layoutId: string }
+  PrintDataForm: { layoutId: string; printDataId: string }
 }

--- a/src/routes/main.routes.tsx
+++ b/src/routes/main.routes.tsx
@@ -7,6 +7,8 @@ import { LayoutEditor } from '@/screens/LayoutEditor'
 import { LayoutFields } from '@/screens/LayoutFields'
 import { LayoutList } from '@/screens/LayoutList'
 import { LayoutPreview } from '@/screens/LayoutPreview'
+import { PrintDataForm } from '@/screens/PrintDataForm'
+import { PrintDataList } from '@/screens/PrintDataList'
 import { Printer } from '@/screens/Printer'
 import { MainName } from './main.constraint'
 import type { MainParams } from './main.params'
@@ -29,6 +31,8 @@ const Routes: React.FC = () => {
       <Stack.Screen name={MainName.ElementEditor} component={ElementEditor} />
       <Stack.Screen name={MainName.LayoutFields} component={LayoutFields} />
       <Stack.Screen name={MainName.LayoutPreview} component={LayoutPreview} />
+      <Stack.Screen name={MainName.PrintDataList} component={PrintDataList} />
+      <Stack.Screen name={MainName.PrintDataForm} component={PrintDataForm} />
     </Stack.Navigator>
   )
 }

--- a/src/screens/LayoutEditor/index.tsx
+++ b/src/screens/LayoutEditor/index.tsx
@@ -40,6 +40,7 @@ type ComponentProps = Props & {
   onPressAdd: () => void
   onPressFields: () => void
   onPressPreview: () => void
+  onPressPrintData: () => void
   isPickerVisible: boolean
   onSelectElementType: (type: LayoutElementType) => void
   onCancelPicker: () => void
@@ -52,6 +53,7 @@ const Component: React.FC<ComponentProps> = ({
   onPressAdd,
   onPressFields,
   onPressPreview,
+  onPressPrintData,
   isPickerVisible,
   onSelectElementType,
   onCancelPicker,
@@ -99,6 +101,11 @@ const Component: React.FC<ComponentProps> = ({
         <Cell
           title="印刷イメージを見る"
           onPress={onPressPreview}
+          accessory="disclosure"
+        />
+        <Cell
+          title="印刷データ"
+          onPress={onPressPrintData}
           accessory="disclosure"
         />
       </Section>
@@ -154,6 +161,10 @@ const Container: React.FC<Props> = (props) => {
     navigation.navigate('LayoutPreview', { layoutId })
   }, [navigation, layoutId])
 
+  const onPressPrintData = useCallback(() => {
+    navigation.navigate('PrintDataList', { layoutId })
+  }, [navigation, layoutId])
+
   const [isPickerVisible, setIsPickerVisible] = useState<boolean>(false)
 
   const onPressAdd = useCallback(() => {
@@ -185,6 +196,7 @@ const Container: React.FC<Props> = (props) => {
         onPressAdd,
         onPressFields,
         onPressPreview,
+        onPressPrintData,
         isPickerVisible,
         onSelectElementType,
         onCancelPicker,

--- a/src/screens/LayoutPreview/index.tsx
+++ b/src/screens/LayoutPreview/index.tsx
@@ -19,9 +19,10 @@ import { makeStyles } from 'react-native-swag-styles'
 import { useSelector } from 'react-redux'
 import { BASE64, COLOR } from '@/CONSTANTS'
 import { createPreviewPrintData, PrintPreview } from '@/components/PrintPreview'
-import type { Layout, PrintCommand } from '@/print'
+import type { Layout, PrintCommand, PrintData } from '@/print'
 import { buildPrintCommands } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
+import { selectPrintDataById } from '@/redux/modules/printData/selectors'
 import { selectPrinterInfo } from '@/redux/modules/printer/selectors'
 import type { MainParams } from '@/routes/main.params'
 import { styleType } from '@/utils/styles'
@@ -36,6 +37,7 @@ const HORIZONTAL_PADDING = 16
 type Props = {}
 type ComponentProps = Props & {
   layout: Layout | undefined
+  isPlaceholder: boolean
   commands: PrintCommand[]
   paperPixelWidth: number
   scale: number
@@ -44,6 +46,7 @@ type ComponentProps = Props & {
 
 const Component: React.FC<ComponentProps> = ({
   layout,
+  isPlaceholder,
   commands,
   paperPixelWidth,
   scale,
@@ -62,8 +65,10 @@ const Component: React.FC<ComponentProps> = ({
   return (
     <View style={styles.container} onLayout={onLayout}>
       <Text style={styles.description}>
-        用紙の幅 {paperPixelWidth}px
-        で描いています。差し込み口は表示名を仮の値として入れています。
+        用紙の幅 {paperPixelWidth}px で描いています。
+        {isPlaceholder
+          ? '差し込み口は表示名を仮の値として入れています。'
+          : null}
       </Text>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         {commands.length === 0 ? (
@@ -92,11 +97,16 @@ const Container: React.FC<Props> = (props) => {
   const navigation = useNavigation()
 
   const {
-    params: { layoutId },
+    params: { layoutId, printDataId },
   } = useRoute<ParamsProps>()
 
-  const selector = useMemo(() => selectLayoutById(layoutId), [layoutId])
-  const layout = useSelector(selector)
+  const layoutSelector = useMemo(() => selectLayoutById(layoutId), [layoutId])
+  const printDataSelector = useMemo(
+    () => selectPrintDataById(printDataId),
+    [printDataId],
+  )
+  const layout = useSelector(layoutSelector)
+  const printData: PrintData | undefined = useSelector(printDataSelector)
   const printerInfo = useSelector(selectPrinterInfo)
 
   const paperPixelWidth = printerInfo?.pixelWidth ?? BASE64.MAX_SIZE
@@ -111,8 +121,12 @@ const Container: React.FC<Props> = (props) => {
     if (!layout) {
       return []
     }
-    return buildPrintCommands(layout, createPreviewPrintData(layout))
-  }, [layout])
+    // 印刷データを指定されていなければ、差し込み口へ仮の値を入れて体裁を見せる
+    return buildPrintCommands(
+      layout,
+      printData ?? createPreviewPrintData(layout),
+    )
+  }, [layout, printData])
 
   const scale = useMemo(() => {
     const usable = availableWidth - HORIZONTAL_PADDING * 2
@@ -129,7 +143,14 @@ const Container: React.FC<Props> = (props) => {
   return (
     <Component
       {...props}
-      {...{ layout, commands, paperPixelWidth, scale, onLayout }}
+      {...{
+        layout,
+        isPlaceholder: !printData,
+        commands,
+        paperPixelWidth,
+        scale,
+        onLayout,
+      }}
     />
   )
 }

--- a/src/screens/PrintDataForm/index.tsx
+++ b/src/screens/PrintDataForm/index.tsx
@@ -1,0 +1,225 @@
+import {
+  type RouteProp,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native'
+import type React from 'react'
+import { useCallback, useLayoutEffect, useMemo } from 'react'
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  useColorScheme,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import { makeStyles } from 'react-native-swag-styles'
+import { useDispatch, useSelector } from 'react-redux'
+import { BASE64, COLOR } from '@/CONSTANTS'
+import { Base64ImageView } from '@/components/Base64ImageView'
+import { Cell, Section } from '@/components/List'
+import type { Layout, LayoutField, PrintData, PrintDataValue } from '@/print'
+import { selectLayoutById } from '@/redux/modules/layout/selectors'
+import { selectPrintDataById } from '@/redux/modules/printData/selectors'
+import { savePrintData } from '@/redux/modules/printData/slice'
+import type { MainParams } from '@/routes/main.params'
+import { styleType } from '@/utils/styles'
+import { createUUID } from '@/utils/uuid'
+import { TextValueCell } from '../ElementEditor/rows'
+
+type ParamsProps = RouteProp<MainParams, 'PrintDataForm'>
+
+type Props = {}
+type ComponentProps = Props & {
+  layout: Layout | undefined
+  printData: PrintData | undefined
+  onChangeTitle: (title: string) => void
+  onChangeValue: (field: LayoutField, value: PrintDataValue) => void
+  onPressPreview: () => void
+}
+
+const textValueOf = (value: PrintDataValue | undefined) =>
+  value?.kind === 'text' ? value.value : ''
+
+const Component: React.FC<ComponentProps> = ({
+  layout,
+  printData,
+  onChangeTitle,
+  onChangeValue,
+  onPressPreview,
+}) => {
+  const styles = useStyles()
+
+  if (!layout || !printData) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>印刷データが見つかりません</Text>
+      </View>
+    )
+  }
+
+  return (
+    <ScrollView style={styles.scrollView}>
+      <Section title="印刷データ">
+        <TextValueCell
+          title="名前"
+          value={printData.title}
+          dialogDescription="一覧に表示する名前です"
+          onChange={onChangeTitle}
+        />
+      </Section>
+
+      {layout.fields.length === 0 ? (
+        <Section title="入力">
+          <Cell
+            title="入力する項目がありません"
+            description="レイアウトの「差し込み口」を追加すると、ここに入力欄が現れます"
+            inactive={true}
+          />
+        </Section>
+      ) : (
+        <Section title="入力">
+          {layout.fields.map((field) =>
+            field.valueType === 'image' ? (
+              <View key={field.id} style={styles.imageRow}>
+                <Text style={styles.imageLabel}>
+                  {field.label || field.key}
+                </Text>
+                <Base64ImageView
+                  base64={
+                    printData.values[field.id]?.kind === 'image'
+                      ? // biome-ignore lint/style/noNonNullAssertion: 直前の判定で画像であることを確かめている
+                        (
+                          printData.values[field.id] as {
+                            asset: { base64: string }
+                          }
+                        ).asset.base64
+                      : undefined
+                  }
+                  onChange={(base64) =>
+                    onChangeValue(field, {
+                      kind: 'image',
+                      asset: {
+                        id: createUUID(),
+                        base64,
+                        width: BASE64.PROFILE_ICON_SIZE,
+                        imageType: 'binary',
+                      },
+                    })
+                  }
+                />
+              </View>
+            ) : (
+              <TextValueCell
+                key={field.id}
+                title={field.label || field.key}
+                value={textValueOf(printData.values[field.id])}
+                keyboardType={field.valueType === 'url' ? 'url' : 'default'}
+                onChange={(value) =>
+                  onChangeValue(field, { kind: 'text', value })
+                }
+              />
+            ),
+          )}
+        </Section>
+      )}
+
+      <Section title="操作">
+        <Cell
+          title="印刷イメージを見る"
+          onPress={onPressPreview}
+          accessory="disclosure"
+        />
+      </Section>
+    </ScrollView>
+  )
+}
+
+const Container: React.FC<Props> = (props) => {
+  const navigation = useNavigation()
+  const dispatch = useDispatch()
+
+  const {
+    params: { layoutId, printDataId },
+  } = useRoute<ParamsProps>()
+
+  const layoutSelector = useMemo(() => selectLayoutById(layoutId), [layoutId])
+  const printDataSelector = useMemo(
+    () => selectPrintDataById(printDataId),
+    [printDataId],
+  )
+  const layout = useSelector(layoutSelector)
+  const printData = useSelector(printDataSelector)
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: printData?.title ?? '印刷データ' })
+  }, [navigation, printData?.title])
+
+  const onChangeTitle = useCallback(
+    (title: string) => {
+      if (!printData) {
+        return
+      }
+      dispatch(savePrintData({ ...printData, title }))
+    },
+    [dispatch, printData],
+  )
+
+  const onChangeValue = useCallback(
+    (field: LayoutField, value: PrintDataValue) => {
+      if (!printData) {
+        return
+      }
+      dispatch(
+        savePrintData({
+          ...printData,
+          values: { ...printData.values, [field.id]: value },
+        }),
+      )
+    },
+    [dispatch, printData],
+  )
+
+  const onPressPreview = useCallback(() => {
+    navigation.navigate('LayoutPreview', { layoutId, printDataId })
+  }, [layoutId, navigation, printDataId])
+
+  return (
+    <Component
+      {...props}
+      {...{ layout, printData, onChangeTitle, onChangeValue, onPressPreview }}
+    />
+  )
+}
+
+export { Container as PrintDataForm }
+
+const useStyles = makeStyles(useColorScheme, (colorScheme) => {
+  const styles = StyleSheet.create({
+    scrollView: styleType<ViewStyle>({
+      flex: 1,
+    }),
+    imageRow: styleType<ViewStyle>({
+      alignItems: 'center',
+      paddingVertical: 16,
+      backgroundColor: COLOR(colorScheme).BACKGROUND.PRIMARY,
+    }),
+    imageLabel: styleType<TextStyle>({
+      alignSelf: 'flex-start',
+      paddingHorizontal: 16,
+      paddingBottom: 8,
+      fontSize: 16,
+      color: COLOR(colorScheme).TEXT.PRIMARY,
+    }),
+    empty: styleType<ViewStyle>({
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    }),
+    emptyText: styleType<TextStyle>({
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+  })
+  return styles
+})

--- a/src/screens/PrintDataList/index.tsx
+++ b/src/screens/PrintDataList/index.tsx
@@ -1,0 +1,252 @@
+import {
+  type RouteProp,
+  useIsFocused,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native'
+import type React from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react'
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  useColorScheme,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import AlertAsync from 'react-native-alert-async'
+import { makeStyles } from 'react-native-swag-styles'
+import { useDispatch, useSelector } from 'react-redux'
+import { COLOR, MESSAGE } from '@/CONSTANTS'
+import { InputDialog } from '@/components/Dialog'
+import { Cell, Section } from '@/components/List'
+import type { Layout, PrintData } from '@/print'
+import { createPrintData } from '@/print'
+import { selectDatabaseIsReady } from '@/redux/modules/database/selectors'
+import { selectLayoutById } from '@/redux/modules/layout/selectors'
+import { selectPrintDataByLayoutId } from '@/redux/modules/printData/selectors'
+import {
+  deletePrintData,
+  duplicatePrintData,
+  fetchPrintData,
+  savePrintData,
+} from '@/redux/modules/printData/slice'
+import type { MainParams } from '@/routes/main.params'
+import { formatDateTime } from '@/utils/day'
+import { styleType } from '@/utils/styles'
+
+type ParamsProps = RouteProp<MainParams, 'PrintDataList'>
+
+type Props = {}
+type ComponentProps = Props & {
+  layout: Layout | undefined
+  printData: PrintData[]
+  isDialogVisible: boolean
+  onPressPrintData: (value: PrintData) => void
+  onLongPressPrintData: (value: PrintData) => void
+  onPressAdd: () => void
+  onSubmitTitle: (title: string) => void
+  onCancelDialog: () => void
+}
+
+const Component: React.FC<ComponentProps> = ({
+  layout,
+  printData,
+  isDialogVisible,
+  onPressPrintData,
+  onLongPressPrintData,
+  onPressAdd,
+  onSubmitTitle,
+  onCancelDialog,
+}) => {
+  const styles = useStyles()
+
+  if (!layout) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>レイアウトが見つかりません</Text>
+      </View>
+    )
+  }
+
+  return (
+    <>
+      <ScrollView style={styles.scrollView}>
+        <Section title="印刷データ">
+          {printData.length === 0 ? (
+            <Cell
+              title="印刷データがありません"
+              description="下の「印刷データを追加する」から作成してください"
+              inactive={true}
+            />
+          ) : (
+            printData.map((value) => (
+              <Cell
+                key={value.id}
+                title={value.title}
+                description={formatDateTime(value.updatedAt)}
+                accessory="disclosure"
+                onPress={() => onPressPrintData(value)}
+                onLongPress={() => onLongPressPrintData(value)}
+              />
+            ))
+          )}
+        </Section>
+        <Section title="操作">
+          <Cell
+            title="印刷データを追加する"
+            description={
+              layout.fields.length === 0
+                ? 'このレイアウトには差し込み口がないため、入力する項目はありません'
+                : 'セルを長押しすると複製と削除ができます'
+            }
+            onPress={onPressAdd}
+          />
+        </Section>
+      </ScrollView>
+      <InputDialog
+        isVisible={isDialogVisible}
+        title="印刷データの追加"
+        description="名前を入力してください"
+        onPress={onSubmitTitle}
+        onCancel={onCancelDialog}
+      />
+    </>
+  )
+}
+
+const Container: React.FC<Props> = (props) => {
+  const navigation = useNavigation()
+  const dispatch = useDispatch()
+  const isFocused = useIsFocused()
+
+  const {
+    params: { layoutId },
+  } = useRoute<ParamsProps>()
+
+  const layoutSelector = useMemo(() => selectLayoutById(layoutId), [layoutId])
+  const printDataSelector = useMemo(
+    () => selectPrintDataByLayoutId(layoutId),
+    [layoutId],
+  )
+  const layout = useSelector(layoutSelector)
+  const printData = useSelector(printDataSelector)
+  const isDatabaseReady = useSelector(selectDatabaseIsReady)
+
+  const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: '印刷データ' })
+  }, [navigation])
+
+  useEffect(() => {
+    if (isFocused && isDatabaseReady) {
+      dispatch(fetchPrintData())
+    }
+  }, [dispatch, isFocused, isDatabaseReady])
+
+  const onPressPrintData = useCallback(
+    (value: PrintData) => {
+      navigation.navigate('PrintDataForm', {
+        layoutId,
+        printDataId: value.id,
+      })
+    },
+    [layoutId, navigation],
+  )
+
+  const onLongPressPrintData = useCallback(
+    async (value: PrintData) => {
+      try {
+        const action = await AlertAsync(value.title, '操作を選んでください', [
+          { text: '複製する', onPress: () => 'duplicate' },
+          { text: '削除する', onPress: () => 'delete', style: 'destructive' },
+          { text: MESSAGE.CANCEL, onPress: () => undefined, style: 'cancel' },
+        ])
+
+        if (action === 'duplicate') {
+          dispatch(duplicatePrintData(value))
+          return
+        }
+
+        if (action === 'delete') {
+          const confirmed = await AlertAsync(
+            '確認',
+            `「${value.title}」を削除しますか？`,
+            [
+              { text: MESSAGE.NO, onPress: () => false, style: 'cancel' },
+              { text: MESSAGE.YES, onPress: () => true },
+            ],
+          )
+          if (confirmed) {
+            dispatch(deletePrintData(value))
+          }
+        }
+      } catch (e: any) {
+        console.warn('onLongPressPrintData', e)
+      }
+    },
+    [dispatch],
+  )
+
+  const onPressAdd = useCallback(() => setIsDialogVisible(true), [])
+  const onCancelDialog = useCallback(() => setIsDialogVisible(false), [])
+
+  const onSubmitTitle = useCallback(
+    (title: string) => {
+      setIsDialogVisible(false)
+      const value = createPrintData(
+        layoutId,
+        title.trim() || '新しい印刷データ',
+      )
+      dispatch(savePrintData(value))
+      navigation.navigate('PrintDataForm', {
+        layoutId,
+        printDataId: value.id,
+      })
+    },
+    [dispatch, layoutId, navigation],
+  )
+
+  return (
+    <Component
+      {...props}
+      {...{
+        layout,
+        printData,
+        isDialogVisible,
+        onPressPrintData,
+        onLongPressPrintData,
+        onPressAdd,
+        onSubmitTitle,
+        onCancelDialog,
+      }}
+    />
+  )
+}
+
+export { Container as PrintDataList }
+
+const useStyles = makeStyles(useColorScheme, (colorScheme) => {
+  const styles = StyleSheet.create({
+    scrollView: styleType<ViewStyle>({
+      flex: 1,
+    }),
+    empty: styleType<ViewStyle>({
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    }),
+    emptyText: styleType<TextStyle>({
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+  })
+  return styles
+})


### PR DESCRIPTION
> [!NOTE]
> [#471](https://github.com/mitsuharu/mobile-printer/pull/471) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

レイアウトへ差し込む値、すなわち印刷データを管理できるようにします。

- `src/database/repositories/printDataRepository.ts` … 印刷データの読み書き
- `src/redux/modules/printData/` … slice / saga / selectors
- `src/screens/PrintDataList/` … 一覧・追加・複製・削除
- `src/screens/PrintDataForm/` … 差し込み口から組み立てる入力フォーム

## 既存の不具合を1件直しています

**レイアウトを保存すると、印刷データの入力内容がすべて消えていました。**

`saveLayout` は差し込み口をまとめて削除してから入れ直していました。`print_data_values.field_id` は `layout_fields(id)` を `ON DELETE CASCADE` で参照しているため、**消していない差し込み口の値まで連鎖削除されます。** レイアウト名を変えただけの保存でも、その時点の入力内容が全部失われる状態でした。

無くなった差し込み口だけを削除し、残るものは更新するよう直しています。印刷データのリポジトリのテストを書いていて見つかったもので、`node:sqlite` に対して実際のスキーマで検証していたから表面化しました。回帰テストとして「保存し直しても値が消えない」「差し込み口を編集しても消えない」「並び順を入れ替えても消えない」「差し込み口を消したときだけ、その値が消える」を追加しています。

## 仕様

- 入力フォームはレイアウトの差し込み口から組み立てます。入力の種類が画像なら画像選択、URLならURL用のキーボードを出します
- 差し込み口がないレイアウトでは、入力する項目がないことを伝えます
- プレビューは印刷データを指定できるようにしました。指定がなければ従来どおり差し込み口へ仮の値を入れて体裁を見せます
- 一覧はセルのタップでフォームへ、長押しで複製と削除です

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし（警告96件、増分は既存コードと同じ `catch (e: any)` によるもの） |
| `TZ=Asia/Tokyo yarn test --runInBand` | 16 suites / 212 tests 成功（本PRで19件追加） |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

作業中に一度実機の接続が切れたため、本PRの画面操作は後続の [#473](https://github.com/mitsuharu/mobile-printer/pull/473) と合わせて確認しました。

- 印刷データの追加と、レイアウトの差し込み口から入力欄が組み立てられること
- 各項目への入力が保存され、一覧に反映されること
- 印刷データを指定した印刷（紙の内容はメンテナーが目視で確認済み）

リポジトリ層は `node:sqlite` に対する実スキーマのテストで検証済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

