### PR TITLE
feat(print): 新レンダラでの実印刷を追加

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,10 +2,10 @@ module.exports = {
   preset: '@react-native/jest-preset',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   setupFiles: ['<rootDir>/jest/setup.js'],
-  // @reduxjs/toolkit が依存する immer は ESM のみを配信しているため、
-  // プリセットの除外へ追加して babel-jest で変換する
+  // immer（@reduxjs/toolkit が依存）と AsyncStorage は ESM のみを配信して
+  // いるため、プリセットの除外へ追加して babel-jest で変換する
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|immer)/)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community|-async-storage)?|immer)/)',
   ],
   moduleNameMapper: {
     '^@op-engineering/op-sqlite$': '<rootDir>/jest/mocks/opSqlite.ts',

--- a/src/print/__test__/executePrintCommands.test.ts
+++ b/src/print/__test__/executePrintCommands.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import type { PrintCommand } from '../commands'
+import { executePrintCommands, type Printer } from '../executePrintCommands'
+
+type Recorded = [string, ...unknown[]]
+
+const createPrinter = () => {
+  const calls: Recorded[] = []
+  const record =
+    (name: string) =>
+    (...args: unknown[]) => {
+      calls.push([name, ...args])
+    }
+
+  const printer: Printer = {
+    setAlignment: record('setAlignment'),
+    setFontSize: record('setFontSize'),
+    setTextStyle: record('setTextStyle'),
+    printText: record('printText'),
+    printImage: record('printImage'),
+    printQRCode: record('printQRCode'),
+    printColumnsString: record('printColumnsString'),
+    printHR: record('printHR'),
+    lineWrap: record('lineWrap'),
+  } as unknown as Printer
+
+  return { printer, calls }
+}
+
+describe('executePrintCommands', () => {
+  it('操作がなければ何も呼ばない', () => {
+    const { printer, calls } = createPrinter()
+    executePrintCommands([], printer)
+    expect(calls).toEqual([])
+  })
+
+  it('すべての操作を対応する呼び出しへ変換する', () => {
+    const { printer, calls } = createPrinter()
+    const commands: PrintCommand[] = [
+      { type: 'setAlignment', alignment: 'center' },
+      { type: 'setFontSize', size: 32 },
+      { type: 'setTextStyle', style: 'bold', enabled: true },
+      { type: 'printText', text: '江本光晴' },
+      { type: 'printImage', base64: 'AAAA', width: 200, imageType: 'binary' },
+      {
+        type: 'printQRCode',
+        text: 'https://example.com/',
+        moduleSize: 8,
+        errorLevel: 'low',
+      },
+      {
+        type: 'printColumns',
+        texts: ['X:', '@mitsuharu_e'],
+        widths: [10, 22],
+        alignments: ['left', 'left'],
+      },
+      { type: 'printHR', barType: 'wave' },
+      { type: 'lineWrap', count: 3 },
+    ]
+
+    executePrintCommands(commands, printer)
+
+    expect(calls).toEqual([
+      ['setAlignment', 'center'],
+      ['setFontSize', 32],
+      ['setTextStyle', 'bold', true],
+      ['printText', '江本光晴'],
+      ['printImage', 'AAAA', 200, 'binary'],
+      ['printQRCode', 'https://example.com/', 8, 'low'],
+      [
+        'printColumnsString',
+        ['X:', '@mitsuharu_e'],
+        [10, 22],
+        ['left', 'left'],
+      ],
+      ['printHR', 'wave'],
+      ['lineWrap', 3],
+    ])
+  })
+
+  it('操作の順序を保つ', () => {
+    const { printer, calls } = createPrinter()
+    executePrintCommands(
+      [
+        { type: 'printText', text: 'A' },
+        { type: 'setFontSize', size: 32 },
+        { type: 'printText', text: 'B' },
+      ],
+      printer,
+    )
+
+    expect(calls.map(([name]) => name)).toEqual([
+      'printText',
+      'setFontSize',
+      'printText',
+    ])
+  })
+
+  it('途中で失敗したらそこで止める', () => {
+    const { printer, calls } = createPrinter()
+    const failing: Printer = {
+      ...printer,
+      printText: jest.fn(() => {
+        throw new Error('printer error')
+      }),
+    }
+
+    expect(() =>
+      executePrintCommands(
+        [
+          { type: 'setFontSize', size: 32 },
+          { type: 'printText', text: 'A' },
+          { type: 'lineWrap', count: 3 },
+        ],
+        failing,
+      ),
+    ).toThrow('printer error')
+
+    expect(calls.map(([name]) => name)).toEqual(['setFontSize'])
+  })
+})

--- a/src/print/executePrintCommands.ts
+++ b/src/print/executePrintCommands.ts
@@ -1,0 +1,101 @@
+import * as SunmiPrinterLibrary from '@mitsuharu/react-native-sunmi-printer-library'
+import { BASE64 } from '@/CONSTANTS'
+import type { PrintCommand } from './commands'
+
+/**
+ * プリンターを操作する範囲
+ *
+ * @note
+ * `SunmiPrinterLibrary` のうち、この処理が使うものだけを切り出している。
+ * こうしておくと、実機なしで呼び出し順を検証できる。
+ */
+export type Printer = {
+  setAlignment: (alignment: SunmiPrinterLibrary.Alignment) => void
+  setFontSize: (size: number) => void
+  setTextStyle: (style: SunmiPrinterLibrary.TextStyle, enabled: boolean) => void
+  printText: (text: string) => void
+  printImage: (
+    base64: string,
+    width: number,
+    type: SunmiPrinterLibrary.PrintImageType,
+  ) => void
+  printQRCode: (
+    text: string,
+    moduleSize: number,
+    errorLevel: SunmiPrinterLibrary.QRErrorLevel,
+  ) => void
+  printColumnsString: (
+    texts: string[],
+    widths: number[],
+    alignments: SunmiPrinterLibrary.Alignment[],
+  ) => void
+  printHR: (barType: SunmiPrinterLibrary.BarType) => void
+  lineWrap: (count: number) => void
+}
+
+/**
+ * @package
+ */
+export const defaultPrinter: Printer = {
+  setAlignment: (alignment) => SunmiPrinterLibrary.setAlignment(alignment),
+  setFontSize: (size) => SunmiPrinterLibrary.setFontSize(size),
+  setTextStyle: (style, enabled) =>
+    SunmiPrinterLibrary.setTextStyle(style, enabled),
+  printText: (text) => SunmiPrinterLibrary.printText(text),
+  printImage: (base64, width, type) =>
+    SunmiPrinterLibrary.printImage(BASE64.PREFIX + base64, width, type),
+  printQRCode: (text, moduleSize, errorLevel) =>
+    SunmiPrinterLibrary.printQRCode(text, moduleSize, errorLevel),
+  printColumnsString: (texts, widths, alignments) =>
+    SunmiPrinterLibrary.printColumnsString(texts, widths, alignments),
+  printHR: (barType) => SunmiPrinterLibrary.printHR(barType),
+  lineWrap: (count) => SunmiPrinterLibrary.lineWrap(count),
+}
+
+/**
+ * 組み立てた操作をプリンターへ送る
+ */
+export const executePrintCommands = (
+  commands: PrintCommand[],
+  printer: Printer = defaultPrinter,
+): void => {
+  for (const command of commands) {
+    switch (command.type) {
+      case 'setAlignment':
+        printer.setAlignment(command.alignment)
+        break
+      case 'setFontSize':
+        printer.setFontSize(command.size)
+        break
+      case 'setTextStyle':
+        printer.setTextStyle(command.style, command.enabled)
+        break
+      case 'printText':
+        printer.printText(command.text)
+        break
+      case 'printImage':
+        printer.printImage(command.base64, command.width, command.imageType)
+        break
+      case 'printQRCode':
+        printer.printQRCode(
+          command.text,
+          command.moduleSize,
+          command.errorLevel,
+        )
+        break
+      case 'printColumns':
+        printer.printColumnsString(
+          command.texts,
+          command.widths,
+          command.alignments,
+        )
+        break
+      case 'printHR':
+        printer.printHR(command.barType)
+        break
+      case 'lineWrap':
+        printer.lineWrap(command.count)
+        break
+    }
+  }
+}

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1,5 +1,6 @@
 export * from './buildPrintCommands'
 export * from './commands'
+export * from './executePrintCommands'
 export * from './factory'
 export * from './mutations'
 export * from './types'

--- a/src/redux/modules/printData/saga/index.ts
+++ b/src/redux/modules/printData/saga/index.ts
@@ -15,14 +15,17 @@ import {
   deletePrintData,
   duplicatePrintData,
   fetchPrintData,
+  printLayout,
   savePrintData,
 } from '../slice'
+import { printLayoutSaga } from './printLayout'
 
 export function* printDataSaga() {
   yield takeLeading(fetchPrintData, fetchPrintDataSaga)
   yield takeEvery(savePrintData, savePrintDataSaga)
   yield takeEvery(duplicatePrintData, duplicatePrintDataSaga)
   yield takeEvery(deletePrintData, deletePrintDataSaga)
+  yield takeLeading(printLayout, printLayoutSaga)
 }
 
 /**

--- a/src/redux/modules/printData/saga/printLayout.ts
+++ b/src/redux/modules/printData/saga/printLayout.ts
@@ -1,0 +1,70 @@
+import * as SunmiPrinterLibrary from '@mitsuharu/react-native-sunmi-printer-library'
+import { call, put, select } from 'redux-saga/effects'
+import type { Layout, PrintCommand, PrintData } from '@/print'
+import { buildPrintCommands, executePrintCommands } from '@/print'
+import { selectLayouts } from '@/redux/modules/layout/selectors'
+import { validatePrinterSaga } from '@/redux/modules/printer/saga/printerSagaUtils'
+import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
+import { selectAllPrintData } from '../selectors'
+import type { printLayout } from '../slice'
+
+/**
+ * @package
+ */
+export function* printLayoutSaga({ payload }: ReturnType<typeof printLayout>) {
+  try {
+    const isPrintable: boolean = yield call(validatePrinterSaga)
+    if (!isPrintable) {
+      return
+    }
+
+    const layouts: Layout[] = yield select(selectLayouts)
+    const layout = layouts.find(({ id }) => id === payload.layoutId)
+    if (!layout) {
+      yield put(
+        enqueueSnackbar({ message: `レイアウトが見つかりませんでした` }),
+      )
+      return
+    }
+
+    let printData: PrintData | undefined
+    if (payload.printDataId) {
+      const values: PrintData[] = yield select(selectAllPrintData)
+      printData = values.find(({ id }) => id === payload.printDataId)
+      if (!printData) {
+        yield put(
+          enqueueSnackbar({ message: `印刷データが見つかりませんでした` }),
+        )
+        return
+      }
+    }
+
+    const commands: PrintCommand[] = yield call(
+      buildPrintCommands,
+      layout,
+      printData,
+    )
+    if (commands.length === 0) {
+      yield put(enqueueSnackbar({ message: `印刷する内容がありません` }))
+      return
+    }
+
+    yield call(print, commands)
+  } catch (e: any) {
+    console.warn('printLayoutSaga', e)
+    yield put(enqueueSnackbar({ message: `印刷に失敗しました` }))
+  }
+}
+
+async function print(commands: PrintCommand[]) {
+  try {
+    // 割り込みを防ぐため、1件の印刷をまとめて送る
+    await SunmiPrinterLibrary.enterPrinterBuffer(true)
+    executePrintCommands(commands)
+  } catch (e: any) {
+    console.warn('print', e)
+    throw e
+  } finally {
+    await SunmiPrinterLibrary.exitPrinterBuffer(true)
+  }
+}

--- a/src/redux/modules/printData/slice.ts
+++ b/src/redux/modules/printData/slice.ts
@@ -37,6 +37,16 @@ const printDataSlice = createSlice({
     duplicatePrintData(_state, _action: PayloadAction<PrintData>) {},
 
     deletePrintData(_state, _action: PayloadAction<PrintData>) {},
+
+    /**
+     * レイアウトを印刷する
+     *
+     * `printDataId` を省略すると、差し込みのない要素だけが印刷される。
+     */
+    printLayout(
+      _state,
+      _action: PayloadAction<{ layoutId: string; printDataId?: string }>,
+    ) {},
   },
 })
 
@@ -47,5 +57,6 @@ export const {
   savePrintData,
   duplicatePrintData,
   deletePrintData,
+  printLayout,
 } = printDataSlice.actions
 export const printDataReducer = printDataSlice.reducer

--- a/src/screens/LayoutEditor/index.tsx
+++ b/src/screens/LayoutEditor/index.tsx
@@ -25,6 +25,7 @@ import type { Layout, LayoutElement, LayoutElementType } from '@/print'
 import { addElement, createLayoutElement, moveElement } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
 import { saveLayout } from '@/redux/modules/layout/slice'
+import { printLayout } from '@/redux/modules/printData/slice'
 import type { MainParams } from '@/routes/main.params'
 import { styleType } from '@/utils/styles'
 import { ElementCell } from './ElementCell'
@@ -41,6 +42,7 @@ type ComponentProps = Props & {
   onPressFields: () => void
   onPressPreview: () => void
   onPressPrintData: () => void
+  onPressPrint: () => void
   isPickerVisible: boolean
   onSelectElementType: (type: LayoutElementType) => void
   onCancelPicker: () => void
@@ -54,6 +56,7 @@ const Component: React.FC<ComponentProps> = ({
   onPressFields,
   onPressPreview,
   onPressPrintData,
+  onPressPrint,
   isPickerVisible,
   onSelectElementType,
   onCancelPicker,
@@ -97,6 +100,11 @@ const Component: React.FC<ComponentProps> = ({
           description={`${layout.fields.length}個`}
           onPress={onPressFields}
           accessory="disclosure"
+        />
+        <Cell
+          title="このレイアウトで印刷する"
+          description="差し込み口は空のまま印刷します"
+          onPress={onPressPrint}
         />
         <Cell
           title="印刷イメージを見る"
@@ -165,6 +173,10 @@ const Container: React.FC<Props> = (props) => {
     navigation.navigate('PrintDataList', { layoutId })
   }, [navigation, layoutId])
 
+  const onPressPrint = useCallback(() => {
+    dispatch(printLayout({ layoutId }))
+  }, [dispatch, layoutId])
+
   const [isPickerVisible, setIsPickerVisible] = useState<boolean>(false)
 
   const onPressAdd = useCallback(() => {
@@ -197,6 +209,7 @@ const Container: React.FC<Props> = (props) => {
         onPressFields,
         onPressPreview,
         onPressPrintData,
+        onPressPrint,
         isPickerVisible,
         onSelectElementType,
         onCancelPicker,

--- a/src/screens/PrintDataForm/index.tsx
+++ b/src/screens/PrintDataForm/index.tsx
@@ -22,7 +22,7 @@ import { Cell, Section } from '@/components/List'
 import type { Layout, LayoutField, PrintData, PrintDataValue } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
 import { selectPrintDataById } from '@/redux/modules/printData/selectors'
-import { savePrintData } from '@/redux/modules/printData/slice'
+import { printLayout, savePrintData } from '@/redux/modules/printData/slice'
 import type { MainParams } from '@/routes/main.params'
 import { styleType } from '@/utils/styles'
 import { createUUID } from '@/utils/uuid'
@@ -37,6 +37,7 @@ type ComponentProps = Props & {
   onChangeTitle: (title: string) => void
   onChangeValue: (field: LayoutField, value: PrintDataValue) => void
   onPressPreview: () => void
+  onPressPrint: () => void
 }
 
 const textValueOf = (value: PrintDataValue | undefined) =>
@@ -48,6 +49,7 @@ const Component: React.FC<ComponentProps> = ({
   onChangeTitle,
   onChangeValue,
   onPressPreview,
+  onPressPrint,
 }) => {
   const styles = useStyles()
 
@@ -126,6 +128,7 @@ const Component: React.FC<ComponentProps> = ({
       )}
 
       <Section title="操作">
+        <Cell title="この内容で印刷する" onPress={onPressPrint} />
         <Cell
           title="印刷イメージを見る"
           onPress={onPressPreview}
@@ -185,10 +188,21 @@ const Container: React.FC<Props> = (props) => {
     navigation.navigate('LayoutPreview', { layoutId, printDataId })
   }, [layoutId, navigation, printDataId])
 
+  const onPressPrint = useCallback(() => {
+    dispatch(printLayout({ layoutId, printDataId }))
+  }, [dispatch, layoutId, printDataId])
+
   return (
     <Component
       {...props}
-      {...{ layout, printData, onChangeTitle, onChangeValue, onPressPreview }}
+      {...{
+        layout,
+        printData,
+        onChangeTitle,
+        onChangeValue,
+        onPressPreview,
+        onPressPrint,
+      }}
     />
   )
 }

--- a/src/screens/PrintDataList/index.tsx
+++ b/src/screens/PrintDataList/index.tsx
@@ -36,6 +36,7 @@ import {
   deletePrintData,
   duplicatePrintData,
   fetchPrintData,
+  printLayout,
   savePrintData,
 } from '@/redux/modules/printData/slice'
 import type { MainParams } from '@/routes/main.params'
@@ -166,10 +167,15 @@ const Container: React.FC<Props> = (props) => {
     async (value: PrintData) => {
       try {
         const action = await AlertAsync(value.title, '操作を選んでください', [
+          { text: '印刷する', onPress: () => 'print' },
           { text: '複製する', onPress: () => 'duplicate' },
           { text: '削除する', onPress: () => 'delete', style: 'destructive' },
-          { text: MESSAGE.CANCEL, onPress: () => undefined, style: 'cancel' },
         ])
+
+        if (action === 'print') {
+          dispatch(printLayout({ layoutId, printDataId: value.id }))
+          return
+        }
 
         if (action === 'duplicate') {
           dispatch(duplicatePrintData(value))
@@ -193,7 +199,7 @@ const Container: React.FC<Props> = (props) => {
         console.warn('onLongPressPrintData', e)
       }
     },
-    [dispatch],
+    [dispatch, layoutId],
   )
 
   const onPressAdd = useCallback(() => setIsDialogVisible(true), [])


### PR DESCRIPTION
> [!NOTE]
> [#472](https://github.com/mitsuharu/mobile-printer/pull/472) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

組み立てた `PrintCommand[]` を実際にプリンターへ送ります。これで**新しいレイアウト印刷が最後まで通り**ます。既存のプロフィール印刷はまだ残っています（撤去は PR9）。

- `src/print/executePrintCommands.ts` … `PrintCommand[]` をプリンターの呼び出しへ変換
- `src/redux/modules/printData/saga/printLayout.ts` … 印刷の実行
- 各画面に印刷の導線

## 設計

**プリンターの操作範囲を型で切り出しました。** `SunmiPrinterLibrary` のうち使うものだけを `Printer` 型にしたので、**実機なしで呼び出しの順序と引数を検証できます。** 「途中で失敗したらそこで止まる」ことまでテストしています。

**1件の印刷は `enterPrinterBuffer` / `exitPrinterBuffer` でまとめて送ります。** 既存のプロフィール印刷と同じく、印刷の途中で別の印刷が割り込むのを防ぐためです。

`printDataId` を省略すると差し込みのない要素だけを印刷します。レイアウトを組んでいる最中に、印刷データを作らずとも体裁を紙で確かめられます。

## 付随する修正

`@react-native-async-storage/async-storage` が ESM のみを配信していて `require` できないため、`transformIgnorePatterns` へ追加しました。印刷経路のテストが `printer` モジュール経由でこれを読み込むようになったためです。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 17 suites / 216 tests 成功（本PRで4件追加） |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

**PR7 の未確認分もあわせて確認しました。**

- 印刷データを追加し、レイアウトの差し込み口から入力欄が2つ組み立てられることを確認
- 各項目へ入力し、値が保存されて一覧に反映されることを確認
- 印刷データの画面から「この内容で印刷する」を実行 → エラーなく完了（スナックバーなし、logcat にエラーなし）
- レイアウト編集画面から「このレイアウトで印刷する」を実行 → 同上

- **紙に出た内容をメンテナーが目視で確認済みです。** 差し込みあり／なしの2枚とも問題なく印刷されました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

