### PR TITLE
refactor(layout): 「差し込み口」を「入力項目」へ改称

### DIFF
--- a/docs/plans/custom-layout-printing.md
+++ b/docs/plans/custom-layout-printing.md
@@ -15,7 +15,7 @@
 
 - ユーザーがテキスト・画像などの**要素を追加・編集・並べ替え**してレイアウトを組める。
 - レイアウトは保存・複製・変更できる。
-- レイアウトとは別に、**印刷データ**（レイアウトへ差し込む値）を管理できる。
+- レイアウトとは別に、**印刷データ**（レイアウトの入力項目へ入れる値）を管理できる。
 - 保存先を SQLite へ移す。
 
 ## 決定事項
@@ -60,7 +60,7 @@
 各要素は内容の供給元を持ちます。
 
 - `{ kind: 'static', value }` … レイアウトに直接埋め込む固定値
-- `{ kind: 'field', fieldId }` … 印刷データから差し込む
+- `{ kind: 'field', fieldId }` … 印刷データごとに入力する
 
 また、現行の `if (alias)` 相当として `hideWhenEmpty`（既定 `true`）を持ち、値が空の要素は印刷時に読み飛ばします。
 
@@ -163,7 +163,7 @@ SQLite を唯一の情報源とし、Redux は画面へ供給するキャッシ�
 | 4 | `codex/layout-repository` | レイアウトのCRUD（リポジトリ + slice + saga + テスト、UIなし） | typecheck / lint / test |
 | 5 | `codex/layout-list-screen` | レイアウト一覧・新規作成・複製・削除のUI | typecheck / lint / test |
 | 6a | `codex/layout-element-reorder` | 要素の追加・削除とドラッグ並べ替え（Reanimated / RNGH 導入） | typecheck / lint / test / Android ビルド / 実機操作 |
-| 6b | `codex/layout-element-editor` | 要素の個別編集と、差し込み口（フィールド）の定義 | typecheck / lint / test / 実機操作 |
+| 6b | `codex/layout-element-editor` | 要素の個別編集と、入力項目（フィールド）の定義 | typecheck / lint / test / 実機操作 |
 | 6c | `codex/layout-preview` | レイアウト編集画面での印刷プレビュー | typecheck / lint / test / 実機で印刷結果と見比べる |
 | 7 | `codex/layout-print-data` | 印刷データのCRUDと、フィールド定義から生成する動的フォーム | typecheck / lint / test |
 | 8 | `codex/layout-print-execution` | 新レンダラでの実印刷 | typecheck / lint / test / 実機印刷 |

--- a/src/components/PrintPreview/__test__/previewData.test.ts
+++ b/src/components/PrintPreview/__test__/previewData.test.ts
@@ -26,7 +26,7 @@ const layout: Layout = {
 }
 
 describe('createPreviewPrintData', () => {
-  it('文字の差し込み口へ表示名を仮の値として入れる', () => {
+  it('文字の入力項目へ表示名を仮の値として入れる', () => {
     expect(createPreviewPrintData(layout).values['field-1']).toEqual({
       kind: 'text',
       value: '［名前］',
@@ -41,16 +41,16 @@ describe('createPreviewPrintData', () => {
     expect(value).toEqual({ kind: 'text', value: '［company］' })
   })
 
-  it('画像の差し込み口には仮の値を入れない', () => {
+  it('画像の入力項目には仮の値を入れない', () => {
     expect(createPreviewPrintData(layout).values['field-2']).toBeUndefined()
   })
 
-  it('仮の値のおかげで、差し込みの要素もプレビューに現れる', () => {
+  it('仮の値のおかげで、入力項目を参照する要素もプレビューに現れる', () => {
     const commands = buildPrintCommands(layout, createPreviewPrintData(layout))
     expect(commands).toContainEqual({ type: 'printText', text: '［名前］' })
   })
 
-  it('印刷データがなければ差し込みの要素は消える', () => {
+  it('印刷データがなければ入力項目を参照する要素は消える', () => {
     expect(buildPrintCommands(layout)).toEqual([])
   })
 })

--- a/src/components/PrintPreview/previewData.ts
+++ b/src/components/PrintPreview/previewData.ts
@@ -1,9 +1,9 @@
 import type { Layout, PrintData } from '@/print'
 
 /**
- * プレビュー用に、差し込み口へ仮の値を入れた印刷データを作る
+ * プレビュー用に、入力項目へ仮の値を入れた印刷データを作る
  *
- * 実際の印刷データがない状態では差し込みが空になり、`hideWhenEmpty` の要素が
+ * 実際の印刷データがない状態では入力項目が空になり、`hideWhenEmpty` の要素が
  * すべて消えて体裁を確かめられない。表示名を仮の値として入れておく。
  */
 export const createPreviewPrintData = (layout: Layout): PrintData => ({

--- a/src/database/__test__/seedPresets.test.ts
+++ b/src/database/__test__/seedPresets.test.ts
@@ -26,7 +26,7 @@ describe('seedPresets', () => {
     )
   })
 
-  it('読み戻したレイアウトの差し込み口と要素がそろっている', async () => {
+  it('読み戻したレイアウトの入力項目と要素がそろっている', async () => {
     await seedPresets(db)
 
     const [layout] = await findAllLayouts(db)

--- a/src/database/migrations/001_initial.ts
+++ b/src/database/migrations/001_initial.ts
@@ -3,7 +3,7 @@ import type { Migration } from './types'
 /**
  * 初版スキーマ
  *
- * レイアウト（体裁とフィールド定義）と、印刷データ（フィールドへ差し込む値）を分けて保存する。
+ * レイアウト（体裁と入力項目の定義）と、印刷データ（入力項目へ入れる値）を分けて保存する。
  * 画像の Base64 は一覧表示のたびに読み込まないよう `image_assets` へ分離する。
  */
 export const initialMigration: Migration = {

--- a/src/database/repositories/__test__/printDataRepository.test.ts
+++ b/src/database/repositories/__test__/printDataRepository.test.ts
@@ -147,17 +147,17 @@ describe('レイアウトとの関係', () => {
     await expect(findAllPrintData(db)).resolves.toEqual([])
   })
 
-  it('レイアウトを保存し直しても、残した差し込み口の値は消えない', async () => {
+  it('レイアウトを保存し直しても、残した入力項目の値は消えない', async () => {
     await savePrintData(db, printData)
 
-    // 名前を変えただけで、差し込み口は消していない
+    // 名前を変えただけで、入力項目は消していない
     await saveLayout(db, { ...layout, name: '名刺2' })
 
     const [loaded] = await findAllPrintData(db)
     expect(loaded.values).toEqual(printData.values)
   })
 
-  it('差し込み口を編集しても値は消えない', async () => {
+  it('入力項目を編集しても値は消えない', async () => {
     await savePrintData(db, printData)
 
     await saveLayout(db, {
@@ -169,7 +169,7 @@ describe('レイアウトとの関係', () => {
     expect(loaded.values).toEqual(printData.values)
   })
 
-  it('差し込み口の並び順を入れ替えても値は消えない', async () => {
+  it('入力項目の並び順を入れ替えても値は消えない', async () => {
     await savePrintData(db, printData)
 
     await saveLayout(db, {
@@ -181,7 +181,7 @@ describe('レイアウトとの関係', () => {
     expect(loaded.values).toEqual(printData.values)
   })
 
-  it('差し込み口を消すと、その値も消える', async () => {
+  it('入力項目を消すと、その値も消える', async () => {
     await savePrintData(db, printData)
 
     await saveLayout(db, { ...layout, fields: [layout.fields[1]] })

--- a/src/database/repositories/layoutRepository.ts
+++ b/src/database/repositories/layoutRepository.ts
@@ -147,8 +147,8 @@ export const saveLayout = async (
       layout.id,
     ])
 
-    // 差し込み口は印刷データの値から参照されている。まとめて消すと、
-    // 残す差し込み口の値まで連鎖削除されるため、無くなったものだけを消す
+    // 入力項目は印刷データの値から参照されている。まとめて消すと、
+    // 残す入力項目の値まで連鎖削除されるため、無くなったものだけを消す
     const fieldIds = layout.fields.map(({ id }) => id)
     const placeholders = fieldIds.map(() => '?').join(', ')
     await tx.execute(

--- a/src/print/__test__/buildPrintCommands.test.ts
+++ b/src/print/__test__/buildPrintCommands.test.ts
@@ -122,7 +122,7 @@ describe('buildPrintCommands text要素', () => {
     ])
   })
 
-  it('印刷データの値を差し込む', () => {
+  it('印刷データの値を入れる', () => {
     const commands = build(
       [textElement({ source: { kind: 'field', fieldId: 'field-1' } })],
       createPrintData({ 'field-1': { kind: 'text', value: '織田信長' } }),
@@ -207,7 +207,7 @@ describe('buildPrintCommands image要素', () => {
     ])
   })
 
-  it('印刷データの画像を差し込む', () => {
+  it('印刷データの画像を入れる', () => {
     const commands = build(
       [imageElement({ source: { kind: 'field', fieldId: 'field-1' } })],
       createPrintData({ 'field-1': { kind: 'image', asset } }),
@@ -319,7 +319,7 @@ describe('buildPrintCommands columns要素', () => {
     ])
   })
 
-  it('差し込んだ値がすべて空なら、固定のラベルが残っていても飛ばす', () => {
+  it('入力した値がすべて空なら、固定のラベルが残っていても飛ばす', () => {
     expect(build([columnsElement()], createPrintData({}))).toEqual([])
   })
 

--- a/src/print/__test__/mutations.test.ts
+++ b/src/print/__test__/mutations.test.ts
@@ -110,7 +110,7 @@ describe('moveElement', () => {
 })
 
 describe('upsertField', () => {
-  it('新しい差し込み口を足す', () => {
+  it('新しい入力項目を足す', () => {
     const next = upsertField(layout, {
       id: 'field-3',
       key: 'qr',
@@ -170,7 +170,7 @@ describe('removeField', () => {
     ],
   }
 
-  it('差し込み口を取り除く', () => {
+  it('入力項目を取り除く', () => {
     expect(
       removeField(withColumns, 'field-1').fields.map(({ id }) => id),
     ).toEqual(['field-2'])
@@ -202,7 +202,7 @@ describe('removeField', () => {
     })
   })
 
-  it('ほかの差し込み口への参照は残す', () => {
+  it('ほかの入力項目への参照は残す', () => {
     const next = removeField(withColumns, 'field-2')
     const element = next.elements[0]
     expect(element.type === 'text' && element.source).toEqual({

--- a/src/print/__test__/presets.test.ts
+++ b/src/print/__test__/presets.test.ts
@@ -35,12 +35,12 @@ describe('createPresets', () => {
     expect(printData.every((value) => value.layoutId === layout.id)).toBe(true)
   })
 
-  it('差し込み口のキーは重複しない', () => {
+  it('入力項目のキーは重複しない', () => {
     const keys = layout.fields.map(({ key }) => key)
     expect(new Set(keys).size).toBe(keys.length)
   })
 
-  it('要素が参照する差し込み口はすべて存在する', () => {
+  it('要素が参照する入力項目はすべて存在する', () => {
     const ids = new Set(layout.fields.map(({ id }) => id))
     const referenced = layout.elements.flatMap((element) => {
       if (element.type === 'columns') {

--- a/src/print/buildPrintCommands.ts
+++ b/src/print/buildPrintCommands.ts
@@ -120,7 +120,7 @@ const columnsCommands = (
   )
 
   if (element.hideWhenEmpty) {
-    // ラベルなどの固定値は判定に含めず、差し込んだ値だけで空行か判断する
+    // ラベルなどの固定値は判定に含めず、入力した値だけで空行か判断する
     const filled = element.columns
       .map((column, index) => ({ column, text: texts[index] }))
       .filter(({ column }) => column.source.kind === 'field')

--- a/src/print/factory.ts
+++ b/src/print/factory.ts
@@ -90,7 +90,7 @@ export const createLayoutElement = (type: LayoutElementType): LayoutElement => {
 }
 
 /**
- * 差し込み口を作る
+ * 入力項目を作る
  */
 export const createLayoutField = (
   values: Partial<Omit<LayoutField, 'id'>> = {},

--- a/src/print/mutations.ts
+++ b/src/print/mutations.ts
@@ -74,7 +74,7 @@ const clearImageSource = (source: ImageSource, fieldId: string): ImageSource =>
     : source
 
 /**
- * 差し込み口を足すか、同じIDのものを差し替える
+ * 入力項目を足すか、同じIDのものを差し替える
  */
 export const upsertField = (layout: Layout, field: LayoutField): Layout => {
   const exists = layout.fields.some(({ id }) => id === field.id)
@@ -87,7 +87,7 @@ export const upsertField = (layout: Layout, field: LayoutField): Layout => {
 }
 
 /**
- * 差し込み口を取り除く
+ * 入力項目を取り除く
  *
  * 参照している要素は参照先を失うため、あわせて固定値へ戻す。
  */
@@ -116,7 +116,7 @@ export const removeField = (layout: Layout, fieldId: string): Layout => ({
 })
 
 /**
- * 差し込み口を参照している要素があるか調べる
+ * 入力項目を参照している要素があるか調べる
  */
 export const isFieldReferenced = (layout: Layout, fieldId: string): boolean =>
   layout.elements.some((element) => {

--- a/src/print/presets/index.ts
+++ b/src/print/presets/index.ts
@@ -14,7 +14,7 @@ import { AVATAR_BASE64 } from './avatar'
 import { SAMPLE_AVATAR_BASE64 } from './sampleAvatar'
 
 /**
- * プリセットの名刺レイアウトが持つ差し込み口
+ * プリセットの名刺レイアウトが持つ入力項目
  */
 const FIELD_KEYS = [
   'name',
@@ -88,7 +88,7 @@ const divider = (): LayoutElement => ({
 })
 
 /**
- * 名刺レイアウトと、その差し込み口のIDを作る
+ * 名刺レイアウトと、その入力項目のIDを作る
  *
  * 従来のプロフィール印刷と同じ体裁を、要素の並びとして組み立てている。
  */

--- a/src/print/types.ts
+++ b/src/print/types.ts
@@ -23,7 +23,7 @@ export type ImageAsset = {
 export type FieldValueType = 'text' | 'multilineText' | 'url' | 'image'
 
 /**
- * レイアウトが宣言する差し込み口
+ * レイアウトが宣言する入力項目
  */
 export type LayoutField = {
   id: string
@@ -154,7 +154,7 @@ export type PrintDataValue =
   | { kind: 'image'; asset: ImageAsset }
 
 /**
- * レイアウトへ差し込む値のひとまとまり
+ * レイアウトの入力項目へ入れる値のひとまとまり
  */
 export type PrintData = {
   id: string

--- a/src/redux/modules/printData/slice.ts
+++ b/src/redux/modules/printData/slice.ts
@@ -41,7 +41,7 @@ const printDataSlice = createSlice({
     /**
      * レイアウトを印刷する
      *
-     * `printDataId` を省略すると、差し込みのない要素だけが印刷される。
+     * `printDataId` を省略すると、入力項目を参照しない要素だけが印刷される。
      */
     printLayout(
       _state,

--- a/src/screens/ElementEditor/ImageSourceSection.tsx
+++ b/src/screens/ElementEditor/ImageSourceSection.tsx
@@ -70,7 +70,7 @@ export const ImageSourceSection: React.FC<Props> = ({
           },
           {
             value: 'field' as SourceKind,
-            title: '印刷データから差し込む',
+            title: '印刷データごとに入力する',
             description: '印刷データごとに画像を変えられます',
           },
         ]}
@@ -85,13 +85,13 @@ export const ImageSourceSection: React.FC<Props> = ({
         </View>
       ) : layout.fields.length === 0 ? (
         <Cell
-          title="差し込み口がありません"
-          description="レイアウトの「差し込み口」から追加してください"
+          title="入力項目がありません"
+          description="レイアウトの「入力項目」から追加してください"
           inactive={true}
         />
       ) : (
         <PickerCell
-          title="差し込み口"
+          title="入力項目"
           value={source.fieldId}
           items={layout.fields.map((field) => ({
             value: field.id,

--- a/src/screens/ElementEditor/TextSourceSection.tsx
+++ b/src/screens/ElementEditor/TextSourceSection.tsx
@@ -14,7 +14,7 @@ type Props = {
 type SourceKind = TextSource['kind']
 
 /**
- * 文字の供給元（固定値か、印刷データからの差し込みか）を編集する
+ * 文字の供給元（レイアウトに固定するか、印刷データごとに入力するか）を編集する
  */
 export const TextSourceSection: React.FC<Props> = ({
   title,
@@ -49,7 +49,7 @@ export const TextSourceSection: React.FC<Props> = ({
           },
           {
             value: 'field' as SourceKind,
-            title: '印刷データから差し込む',
+            title: '印刷データごとに入力する',
             description: '印刷データごとに内容を変えられます',
           },
         ]}
@@ -63,13 +63,13 @@ export const TextSourceSection: React.FC<Props> = ({
         />
       ) : layout.fields.length === 0 ? (
         <Cell
-          title="差し込み口がありません"
-          description="レイアウトの「差し込み口」から追加してください"
+          title="入力項目がありません"
+          description="レイアウトの「入力項目」から追加してください"
           inactive={true}
         />
       ) : (
         <PickerCell
-          title="差し込み口"
+          title="入力項目"
           value={source.fieldId}
           items={layout.fields.map((field) => ({
             value: field.id,

--- a/src/screens/LayoutEditor/__test__/describeElement.test.ts
+++ b/src/screens/LayoutEditor/__test__/describeElement.test.ts
@@ -56,7 +56,7 @@ describe('describeElement text', () => {
     expect(describe1(text({ kind: 'static', value: '  ' }))).toBe('（未入力）')
   })
 
-  it('差し込みはフィールド名を表示する', () => {
+  it('入力項目を参照するときは項目名を表示する', () => {
     expect(describe1(text({ kind: 'field', fieldId: 'field-1' }))).toBe(
       '［名前］',
     )

--- a/src/screens/LayoutEditor/index.tsx
+++ b/src/screens/LayoutEditor/index.tsx
@@ -96,14 +96,14 @@ const Component: React.FC<ComponentProps> = ({
       <Section>
         <Cell title="要素を追加する" onPress={onPressAdd} />
         <Cell
-          title="差し込み口"
+          title="入力項目"
           description={`${layout.fields.length}個`}
           onPress={onPressFields}
           accessory="disclosure"
         />
         <Cell
           title="このレイアウトで印刷する"
-          description="差し込み口は空のまま印刷します"
+          description="入力項目は空のまま印刷します"
           onPress={onPressPrint}
         />
         <Cell

--- a/src/screens/LayoutFields/index.tsx
+++ b/src/screens/LayoutFields/index.tsx
@@ -70,14 +70,14 @@ const Component: React.FC<ComponentProps> = ({
     <>
       <ScrollView style={styles.scrollView}>
         <Text style={styles.description}>
-          差し込み口は、印刷データごとに内容を変えたい箇所です。要素の「内容の決め方」で
-          「印刷データから差し込む」を選ぶと、ここで作った差し込み口を指定できます。
+          入力項目は、印刷データごとに内容を変えたい箇所です。要素の「内容の決め方」で
+          「印刷データごとに入力する」を選ぶと、ここで作った入力項目を指定できます。
         </Text>
         {layout.fields.length === 0 ? (
-          <Section title="差し込み口">
+          <Section title="入力項目">
             <Cell
-              title="差し込み口がありません"
-              description="下の「差し込み口を追加する」から作成してください"
+              title="入力項目がありません"
+              description="下の「入力項目を追加する」から作成してください"
               inactive={true}
             />
           </Section>
@@ -102,19 +102,19 @@ const Component: React.FC<ComponentProps> = ({
                 onChange={(valueType) => onChangeField({ ...field, valueType })}
               />
               <Cell
-                title="この差し込み口を削除する"
+                title="この入力項目を削除する"
                 onPress={() => onDeleteField(field)}
               />
             </Section>
           ))
         )}
         <Section title="操作">
-          <Cell title="差し込み口を追加する" onPress={onPressAdd} />
+          <Cell title="入力項目を追加する" onPress={onPressAdd} />
         </Section>
       </ScrollView>
       <InputDialog
         isVisible={isDialogVisible}
-        title="差し込み口の追加"
+        title="入力項目の追加"
         description="表示名を入力してください"
         onPress={onSubmitLabel}
         onCancel={onCancelDialog}
@@ -137,7 +137,7 @@ const Container: React.FC<Props> = (props) => {
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
 
   useLayoutEffect(() => {
-    navigation.setOptions({ title: '差し込み口' })
+    navigation.setOptions({ title: '入力項目' })
   }, [navigation])
 
   const onChangeField = useCallback(
@@ -160,7 +160,7 @@ const Container: React.FC<Props> = (props) => {
         const confirmed = await AlertAsync(
           '確認',
           referenced
-            ? `「${field.label || field.key}」を削除しますか？\nこの差し込み口を使っている要素は、内容が空の固定値に戻ります。`
+            ? `「${field.label || field.key}」を削除しますか？\nこの入力項目を使っている要素は、内容が空の固定値に戻ります。`
             : `「${field.label || field.key}」を削除しますか？`,
           [
             { text: MESSAGE.NO, onPress: () => false, style: 'cancel' },
@@ -192,7 +192,7 @@ const Container: React.FC<Props> = (props) => {
           upsertField(
             layout,
             createLayoutField({
-              label: trimmed || '差し込み口',
+              label: trimmed || '入力項目',
               key: trimmed || `field${layout.fields.length + 1}`,
             }),
           ),

--- a/src/screens/LayoutPreview/index.tsx
+++ b/src/screens/LayoutPreview/index.tsx
@@ -66,9 +66,7 @@ const Component: React.FC<ComponentProps> = ({
     <View style={styles.container} onLayout={onLayout}>
       <Text style={styles.description}>
         用紙の幅 {paperPixelWidth}px で描いています。
-        {isPlaceholder
-          ? '差し込み口は表示名を仮の値として入れています。'
-          : null}
+        {isPlaceholder ? '入力項目は表示名を仮の値として入れています。' : null}
       </Text>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         {commands.length === 0 ? (
@@ -121,7 +119,7 @@ const Container: React.FC<Props> = (props) => {
     if (!layout) {
       return []
     }
-    // 印刷データを指定されていなければ、差し込み口へ仮の値を入れて体裁を見せる
+    // 印刷データを指定されていなければ、入力項目へ仮の値を入れて体裁を見せる
     return buildPrintCommands(
       layout,
       printData ?? createPreviewPrintData(layout),

--- a/src/screens/PrintDataForm/index.tsx
+++ b/src/screens/PrintDataForm/index.tsx
@@ -76,7 +76,7 @@ const Component: React.FC<ComponentProps> = ({
         <Section title="入力">
           <Cell
             title="入力する項目がありません"
-            description="レイアウトの「差し込み口」を追加すると、ここに入力欄が現れます"
+            description="レイアウトの「入力項目」を追加すると、ここに入力欄が現れます"
             inactive={true}
           />
         </Section>

--- a/src/screens/PrintDataList/index.tsx
+++ b/src/screens/PrintDataList/index.tsx
@@ -105,7 +105,7 @@ const Component: React.FC<ComponentProps> = ({
             title="印刷データを追加する"
             description={
               layout.fields.length === 0
-                ? 'このレイアウトには差し込み口がないため、入力する項目はありません'
+                ? 'このレイアウトには入力項目がないため、入力する項目はありません'
                 : 'セルを長押しすると複製と削除ができます'
             }
             onPress={onPressAdd}


### PR DESCRIPTION
> [!NOTE]
> [#474](https://github.com/mitsuharu/mobile-printer/pull/474) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

**表示文言のみの変更です。** 保存する内容や型の名前（`LayoutField` など）は変えていません。

レビューで「差し込み口は一般的ではなく分かりにくい」との指摘を受けての対応です。この語は実装時にこちらで作ったもので、一般的な言い回しではありませんでした。

## 変更

| 変更前 | 変更後 |
| --- | --- |
| 差し込み口 | 入力項目 |
| 印刷データから差し込む | 印刷データごとに入力する |

レイアウトの要素は**固定値か入力可能かのどちらか**です。呼び名を入力側へ寄せることで、「レイアウトに直接書く」との対比がそのまま固定と入力の違いとして読めるようになります。

コード内のコメントとテスト名も、同じ語彙へそろえました。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 232 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- レイアウト編集画面が「入力項目 13個」になっている
- 要素の「内容の決め方」が「レイアウトに直接書く」/「印刷データごとに入力する」の対比になっている
- 参照先のセルが「入力項目」になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
