### PR TITLE
fix(ui): 印刷データ編集の動線を短くし、ナビゲーションバーとの重なりを直す

### DIFF
--- a/src/components/SafeScrollView/index.tsx
+++ b/src/components/SafeScrollView/index.tsx
@@ -1,0 +1,36 @@
+import type React from 'react'
+import {
+  ScrollView,
+  type ScrollViewProps,
+  StyleSheet,
+  type ViewStyle,
+} from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { styleType } from '@/utils/styles'
+
+/**
+ * 端末のナビゲーションバーの上までで描画を止める ScrollView
+ *
+ * @note
+ * 下端に余白を足すだけでは、スクロール中の内容がナビゲーションバーの下を
+ * 通り抜けて重なって見える。表示領域そのものを狭めて重ならないようにする。
+ */
+export const SafeScrollView: React.FC<ScrollViewProps> = ({
+  style,
+  ...props
+}) => {
+  return (
+    <SafeAreaView style={[styles.container, style]} edges={['bottom']}>
+      <ScrollView {...props} style={styles.scrollView} />
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: styleType<ViewStyle>({
+    flex: 1,
+  }),
+  scrollView: styleType<ViewStyle>({
+    flex: 1,
+  }),
+})

--- a/src/screens/ElementEditor/index.tsx
+++ b/src/screens/ElementEditor/index.tsx
@@ -6,7 +6,6 @@ import {
 import type React from 'react'
 import { useCallback, useLayoutEffect, useMemo } from 'react'
 import {
-  ScrollView,
   StyleSheet,
   Text,
   type TextStyle,
@@ -19,6 +18,7 @@ import { makeStyles } from 'react-native-swag-styles'
 import { useDispatch, useSelector } from 'react-redux'
 import { BASE64, COLOR, MESSAGE } from '@/CONSTANTS'
 import { Cell, Section } from '@/components/List'
+import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, LayoutElement } from '@/print'
 import { removeElement, replaceElement } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
@@ -79,7 +79,7 @@ const Component: React.FC<ComponentProps> = ({
   }
 
   return (
-    <ScrollView style={styles.scrollView}>
+    <SafeScrollView style={styles.scrollView}>
       {element.type === 'text' && (
         <>
           <TextSourceSection
@@ -319,7 +319,7 @@ const Component: React.FC<ComponentProps> = ({
       <Section title="操作">
         <Cell title="この要素を削除する" onPress={onDelete} />
       </Section>
-    </ScrollView>
+    </SafeScrollView>
   )
 }
 

--- a/src/screens/Home/PrintDataCell.tsx
+++ b/src/screens/Home/PrintDataCell.tsx
@@ -1,0 +1,91 @@
+import type React from 'react'
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  type TextStyle,
+  useColorScheme,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import { makeStyles } from 'react-native-swag-styles'
+import Icon from 'react-native-vector-icons/MaterialIcons'
+import { COLOR } from '@/CONSTANTS'
+import { Button } from '@/components/Button'
+import { contentInset } from '@/components/List/util'
+import type { PrintData } from '@/print'
+import { styleType } from '@/utils/styles'
+
+type Props = {
+  printData: PrintData
+  layoutName?: string
+  onPressPrint: (printData: PrintData) => void
+  onPressEdit: (printData: PrintData) => void
+}
+
+/**
+ * ホームに並べる印刷データ
+ *
+ * 本体をタップすると印刷し、右のボタンから内容の編集へ進む。
+ * 編集を階層の奥に置くと、印刷内容を直すたびに何度もたどることになる。
+ */
+export const PrintDataCell: React.FC<Props> = ({
+  printData,
+  layoutName,
+  onPressPrint,
+  onPressEdit,
+}) => {
+  const styles = useStyles()
+
+  return (
+    <View style={styles.container}>
+      <Button style={styles.content} onPress={() => onPressPrint(printData)}>
+        <Text style={styles.title}>{printData.title}</Text>
+        {!!layoutName && <Text style={styles.subtitle}>{layoutName}</Text>}
+      </Button>
+      <Pressable
+        style={styles.edit}
+        onPress={() => onPressEdit(printData)}
+        accessibilityLabel={`${printData.title}を編集する`}
+        accessibilityRole="button"
+        hitSlop={8}
+      >
+        <Icon name="edit" size={22} style={styles.editIcon} />
+      </Pressable>
+    </View>
+  )
+}
+
+const useStyles = makeStyles(useColorScheme, (colorScheme) => {
+  const styles = StyleSheet.create({
+    container: styleType<ViewStyle>({
+      flexDirection: 'row',
+      alignItems: 'center',
+      minHeight: 44,
+      paddingLeft: contentInset.left,
+      paddingRight: 8,
+      backgroundColor: COLOR(colorScheme).BACKGROUND.PRIMARY,
+    }),
+    content: styleType<ViewStyle>({
+      flex: 1,
+      justifyContent: 'center',
+      paddingVertical: contentInset.top,
+    }),
+    title: styleType<TextStyle>({
+      fontSize: 16,
+      color: COLOR(colorScheme).TEXT.PRIMARY,
+    }),
+    subtitle: styleType<TextStyle>({
+      fontSize: 12,
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+    edit: styleType<ViewStyle>({
+      paddingHorizontal: 12,
+      paddingVertical: 12,
+    }),
+    editIcon: styleType<TextStyle>({
+      color: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+  })
+  return styles
+})

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -1,10 +1,11 @@
 import { useIsFocused, useNavigation } from '@react-navigation/native'
 import type React from 'react'
 import { useCallback, useEffect, useLayoutEffect, useMemo } from 'react'
-import { ScrollView, StyleSheet, type ViewStyle } from 'react-native'
+import { StyleSheet, type ViewStyle } from 'react-native'
 import { makeStyles } from 'react-native-swag-styles'
 import { useDispatch, useSelector } from 'react-redux'
 import { Cell, Section } from '@/components/List'
+import { SafeScrollView } from '@/components/SafeScrollView'
 import { SeasonalAsciiArtSection } from '@/components/SeasonalAsciiArtSection'
 import type { Layout, PrintData } from '@/print'
 import { selectDatabaseIsReady } from '@/redux/modules/database/selectors'
@@ -15,6 +16,7 @@ import { fetchPrintData, printLayout } from '@/redux/modules/printData/slice'
 import { printText } from '@/redux/modules/printer/slice'
 import { styleType } from '@/utils/styles'
 import { InputDialogCell } from './InputDialogCell'
+import { PrintDataCell } from './PrintDataCell'
 
 type Props = {}
 type ComponentProps = Props & {
@@ -22,6 +24,7 @@ type ComponentProps = Props & {
   layoutNames: Record<string, string>
   onPressText: (text: string) => void
   onPressPrintData: (value: PrintData) => void
+  onPressEditPrintData: (value: PrintData) => void
   onNavigateToPrinter: () => void
   onNavigateToLayoutList: () => void
 }
@@ -31,13 +34,14 @@ const Component: React.FC<ComponentProps> = ({
   layoutNames,
   onPressText,
   onPressPrintData,
+  onPressEditPrintData,
   onNavigateToPrinter,
   onNavigateToLayoutList,
 }) => {
   const styles = useStyles()
 
   return (
-    <ScrollView style={styles.scrollView}>
+    <SafeScrollView style={styles.scrollView}>
       <SeasonalAsciiArtSection />
       <Section title="汎用印刷">
         <InputDialogCell
@@ -61,11 +65,12 @@ const Component: React.FC<ComponentProps> = ({
           />
         ) : (
           printData.map((value) => (
-            <Cell
+            <PrintDataCell
               key={value.id}
-              title={value.title}
-              description={layoutNames[value.layoutId]}
-              onPress={() => onPressPrintData(value)}
+              printData={value}
+              layoutName={layoutNames[value.layoutId]}
+              onPressPrint={onPressPrintData}
+              onPressEdit={onPressEditPrintData}
             />
           ))
         )}
@@ -78,7 +83,7 @@ const Component: React.FC<ComponentProps> = ({
           accessory="disclosure"
         />
       </Section>
-    </ScrollView>
+    </SafeScrollView>
   )
 }
 
@@ -122,6 +127,16 @@ const Container: React.FC<Props> = (props) => {
     [dispatch],
   )
 
+  const onPressEditPrintData = useCallback(
+    (value: PrintData) => {
+      navigation.navigate('PrintDataForm', {
+        layoutId: value.layoutId,
+        printDataId: value.id,
+      })
+    },
+    [navigation],
+  )
+
   const onNavigateToPrinter = useCallback(() => {
     navigation.navigate('Printer')
   }, [navigation])
@@ -138,6 +153,7 @@ const Container: React.FC<Props> = (props) => {
         layoutNames,
         onPressText,
         onPressPrintData,
+        onPressEditPrintData,
         onNavigateToPrinter,
         onNavigateToLayoutList,
       }}

--- a/src/screens/LayoutFields/index.tsx
+++ b/src/screens/LayoutFields/index.tsx
@@ -6,7 +6,6 @@ import {
 import type React from 'react'
 import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import {
-  ScrollView,
   StyleSheet,
   Text,
   type TextStyle,
@@ -20,6 +19,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { COLOR, MESSAGE } from '@/CONSTANTS'
 import { InputDialog } from '@/components/Dialog'
 import { Cell, Section } from '@/components/List'
+import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, LayoutField } from '@/print'
 import {
   createLayoutField,
@@ -68,7 +68,7 @@ const Component: React.FC<ComponentProps> = ({
 
   return (
     <>
-      <ScrollView style={styles.scrollView}>
+      <SafeScrollView style={styles.scrollView}>
         <Text style={styles.description}>
           入力項目は、印刷データごとに内容を変えたい箇所です。要素の「内容の決め方」で
           「印刷データごとに入力する」を選ぶと、ここで作った入力項目を指定できます。
@@ -111,7 +111,7 @@ const Component: React.FC<ComponentProps> = ({
         <Section title="操作">
           <Cell title="入力項目を追加する" onPress={onPressAdd} />
         </Section>
-      </ScrollView>
+      </SafeScrollView>
       <InputDialog
         isVisible={isDialogVisible}
         title="入力項目の追加"

--- a/src/screens/LayoutList/index.tsx
+++ b/src/screens/LayoutList/index.tsx
@@ -1,13 +1,14 @@
 import { useIsFocused, useNavigation } from '@react-navigation/native'
 import type React from 'react'
 import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
-import { ScrollView, StyleSheet, type ViewStyle } from 'react-native'
+import { StyleSheet, type ViewStyle } from 'react-native'
 import AlertAsync from 'react-native-alert-async'
 import { makeStyles } from 'react-native-swag-styles'
 import { useDispatch, useSelector } from 'react-redux'
 import { MESSAGE } from '@/CONSTANTS'
 import { InputDialog } from '@/components/Dialog'
 import { Cell, Section } from '@/components/List'
+import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout } from '@/print'
 import { createLayout } from '@/print'
 import { selectDatabaseIsReady } from '@/redux/modules/database/selectors'
@@ -45,7 +46,7 @@ const Component: React.FC<ComponentProps> = ({
 
   return (
     <>
-      <ScrollView style={styles.scrollView}>
+      <SafeScrollView style={styles.scrollView}>
         <Section title="レイアウト">
           {layouts.length === 0 ? (
             <Cell
@@ -73,7 +74,7 @@ const Component: React.FC<ComponentProps> = ({
             onPress={onPressAdd}
           />
         </Section>
-      </ScrollView>
+      </SafeScrollView>
       <InputDialog
         isVisible={isDialogVisible}
         title="レイアウトの追加"

--- a/src/screens/LayoutPreview/index.tsx
+++ b/src/screens/LayoutPreview/index.tsx
@@ -15,6 +15,7 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { makeStyles } from 'react-native-swag-styles'
 import { useSelector } from 'react-redux'
 import { BASE64, COLOR } from '@/CONSTANTS'
@@ -63,7 +64,11 @@ const Component: React.FC<ComponentProps> = ({
   }
 
   return (
-    <View style={styles.container} onLayout={onLayout}>
+    <SafeAreaView
+      style={styles.container}
+      edges={['bottom']}
+      onLayout={onLayout}
+    >
       <Text style={styles.description}>
         用紙の幅 {paperPixelWidth}px で描いています。
         {isPlaceholder ? '入力項目は表示名を仮の値として入れています。' : null}
@@ -87,7 +92,7 @@ const Component: React.FC<ComponentProps> = ({
           </View>
         )}
       </ScrollView>
-    </View>
+    </SafeAreaView>
   )
 }
 

--- a/src/screens/PrintDataForm/index.tsx
+++ b/src/screens/PrintDataForm/index.tsx
@@ -6,7 +6,6 @@ import {
 import type React from 'react'
 import { useCallback, useLayoutEffect, useMemo } from 'react'
 import {
-  ScrollView,
   StyleSheet,
   Text,
   type TextStyle,
@@ -19,6 +18,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { BASE64, COLOR } from '@/CONSTANTS'
 import { Base64ImageView } from '@/components/Base64ImageView'
 import { Cell, Section } from '@/components/List'
+import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, LayoutField, PrintData, PrintDataValue } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
 import { selectPrintDataById } from '@/redux/modules/printData/selectors'
@@ -38,6 +38,7 @@ type ComponentProps = Props & {
   onChangeValue: (field: LayoutField, value: PrintDataValue) => void
   onPressPreview: () => void
   onPressPrint: () => void
+  onPressLayout: () => void
 }
 
 const textValueOf = (value: PrintDataValue | undefined) =>
@@ -50,6 +51,7 @@ const Component: React.FC<ComponentProps> = ({
   onChangeValue,
   onPressPreview,
   onPressPrint,
+  onPressLayout,
 }) => {
   const styles = useStyles()
 
@@ -62,7 +64,7 @@ const Component: React.FC<ComponentProps> = ({
   }
 
   return (
-    <ScrollView style={styles.scrollView}>
+    <SafeScrollView style={styles.scrollView}>
       <Section title="印刷データ">
         <TextValueCell
           title="名前"
@@ -134,8 +136,14 @@ const Component: React.FC<ComponentProps> = ({
           onPress={onPressPreview}
           accessory="disclosure"
         />
+        <Cell
+          title="レイアウトを編集する"
+          description={layout.name}
+          onPress={onPressLayout}
+          accessory="disclosure"
+        />
       </Section>
-    </ScrollView>
+    </SafeScrollView>
   )
 }
 
@@ -192,6 +200,10 @@ const Container: React.FC<Props> = (props) => {
     dispatch(printLayout({ layoutId, printDataId }))
   }, [dispatch, layoutId, printDataId])
 
+  const onPressLayout = useCallback(() => {
+    navigation.navigate('LayoutEditor', { layoutId })
+  }, [layoutId, navigation])
+
   return (
     <Component
       {...props}
@@ -202,6 +214,7 @@ const Container: React.FC<Props> = (props) => {
         onChangeValue,
         onPressPreview,
         onPressPrint,
+        onPressLayout,
       }}
     />
   )

--- a/src/screens/PrintDataList/index.tsx
+++ b/src/screens/PrintDataList/index.tsx
@@ -13,7 +13,6 @@ import {
   useState,
 } from 'react'
 import {
-  ScrollView,
   StyleSheet,
   Text,
   type TextStyle,
@@ -27,6 +26,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { COLOR, MESSAGE } from '@/CONSTANTS'
 import { InputDialog } from '@/components/Dialog'
 import { Cell, Section } from '@/components/List'
+import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, PrintData } from '@/print'
 import { createPrintData } from '@/print'
 import { selectDatabaseIsReady } from '@/redux/modules/database/selectors'
@@ -79,7 +79,7 @@ const Component: React.FC<ComponentProps> = ({
 
   return (
     <>
-      <ScrollView style={styles.scrollView}>
+      <SafeScrollView style={styles.scrollView}>
         <Section title="印刷データ">
           {printData.length === 0 ? (
             <Cell
@@ -111,7 +111,7 @@ const Component: React.FC<ComponentProps> = ({
             onPress={onPressAdd}
           />
         </Section>
-      </ScrollView>
+      </SafeScrollView>
       <InputDialog
         isVisible={isDialogVisible}
         title="印刷データの追加"


### PR DESCRIPTION
> [!NOTE]
> [#476](https://github.com/mitsuharu/mobile-printer/pull/476) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

レビューでいただいた2点の対応です。

## 1. 印刷データ編集の動線が深い

印刷内容を直すのに、**ホーム → レイアウトを管理する → レイアウトを選ぶ → 印刷データ → 印刷データを選ぶ → 編集**とたどる必要がありました。印刷内容の修正は繰り返す操作なので、階層の奥に置くべきではありませんでした。

- **ホームの印刷データに編集ボタンを追加**しました。行のタップで印刷、右のボタンで編集画面へ直行します（**2タップ**）
- **印刷データの画面から「レイアウトを編集する」で、レイアウト編集へ移動**できるようにしました。内容を直していて体裁も直したくなったときに、ホームまで戻らずに済みます

行のタップは従来どおり印刷のままなので、印刷の手数は増えていません。

## 2. ナビゲーションバーとの重なり

一覧やフォームの下端が、端末のナビゲーションバーと重なっていました。

**下端に余白を足すだけでは不十分**でした。それだと最後の項目は届くようになりますが、**スクロール中の内容がナビゲーションバーの下を通り抜けて重なって見えます。** 表示領域そのものを狭める `SafeScrollView` を用意し、レイアウト印刷の各画面（ホーム／レイアウト一覧／入力項目／要素編集／印刷データ一覧／印刷データ）で使うようにしました。プレビュー画面も同様に直しています。

## 補足：レイアウトの付け替えについて

印刷データの画面から**レイアウトの編集へ移動する**ことはできますが、**その印刷データを別のレイアウトへ付け替える**ことはできません。入力項目のIDはレイアウトごとに固有なので、付け替えると入力済みの値の対応が取れなくなるためです。必要であれば別途ご相談ください。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 232 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- ホームの各印刷データに編集ボタンが並ぶ
- 編集ボタンから2タップで印刷データの入力画面へ到達する
- 印刷データの画面を最下部までスクロールしても、内容がナビゲーションバーと重ならない
- スクロール中も内容がナビゲーションバーの下を通り抜けない
- 最下部に「レイアウトを編集する」が表示され、レイアウト編集へ移動できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)


