### PR TITLE
fix(ui): 数値の入力欄に単位を入れないようにする

### DIFF
--- a/src/screens/ElementEditor/rows/NumberValueCell.tsx
+++ b/src/screens/ElementEditor/rows/NumberValueCell.tsx
@@ -14,6 +14,8 @@ type Props = {
 /**
  * タップして数値を入れ直すセル
  *
+ * セルには単位を添えて表示するが、入力欄には数値だけを入れる。単位まで入れると、
+ * 入力し直すたびに単位を消す手間がかかる。
  * 範囲の外や数値でない入力は捨てて、元の値を保つ。
  */
 export const NumberValueCell: React.FC<Props> = ({
@@ -41,7 +43,8 @@ export const NumberValueCell: React.FC<Props> = ({
   return (
     <TextValueCell
       title={title}
-      value={`${value}${unit ?? ''}`}
+      value={String(value)}
+      displayValue={`${value}${unit ?? ''}`}
       dialogDescription={`${min}〜${max} の数値を入力してください`}
       keyboardType="number-pad"
       onChange={onChangeText}

--- a/src/screens/ElementEditor/rows/TextValueCell.tsx
+++ b/src/screens/ElementEditor/rows/TextValueCell.tsx
@@ -6,7 +6,19 @@ import { Cell } from '@/components/List'
 
 type Props = {
   title: string
+
+  /**
+   * 入力欄に入れる値
+   */
   value: string
+
+  /**
+   * セルに表示する文字
+   *
+   * 単位を添えるなど、表示と入力を分けたいときに使う。省略すると値をそのまま表示する。
+   */
+  displayValue?: string
+
   placeholder?: string
   dialogDescription?: string
   keyboardType?: KeyboardTypeOptions
@@ -19,6 +31,7 @@ type Props = {
 export const TextValueCell: React.FC<Props> = ({
   title,
   value,
+  displayValue,
   placeholder,
   dialogDescription,
   keyboardType,
@@ -40,7 +53,9 @@ export const TextValueCell: React.FC<Props> = ({
     <>
       <Cell
         title={title}
-        description={value === '' ? (placeholder ?? '（未設定）') : value}
+        description={
+          value === '' ? (placeholder ?? '（未設定）') : (displayValue ?? value)
+        }
         onPress={onPress}
       />
       <InputDialog


### PR DESCRIPTION
> [!NOTE]
> [#478](https://github.com/mitsuharu/mobile-printer/pull/478) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

「空ける行数」などの数値の項目で、**入力欄に「1行」と単位ごと入っていた**ため、入れ直すたびに単位を消す必要がありました。

セルに表示する文字と入力欄に入れる値を分け、**セルは「1行」、入力欄は「1」**とします。`TextValueCell` に `displayValue` を足し、`NumberValueCell` から表示用の文字を渡すようにしました。

対象は空ける行数のほか、画像の印刷幅（px）、列の幅（文字）、QRコードの大きさです。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 232 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- 空白要素のセルが「空ける行数 / 1行」と表示される
- タップして開く入力欄には「1」だけが入っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
