### PR TITLE
perf(layout): 画面遷移ごとのDB読み込みをやめ、読み込み中を表示する

### DIFF
--- a/src/redux/modules/database/saga.ts
+++ b/src/redux/modules/database/saga.ts
@@ -4,6 +4,8 @@ import {
   initializeDatabase,
   seedPresets,
 } from '@/database'
+import { fetchLayouts } from '@/redux/modules/layout/slice'
+import { fetchPrintData } from '@/redux/modules/printData/slice'
 import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
 import { assignIsReady } from './slice'
 
@@ -15,6 +17,10 @@ export function* databaseSaga() {
       yield call(seedPresets, connection)
     }
     yield put(assignIsReady(true))
+
+    // 書き込みのたびに写しを作り直しているため、読み込みは起動時の一度で足りる
+    yield put(fetchLayouts())
+    yield put(fetchPrintData())
   } catch (e: any) {
     console.warn('databaseSaga', e)
     yield put(assignIsReady(false))

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -5,10 +5,14 @@ import { StyleSheet, type ViewStyle } from 'react-native'
 import { makeStyles } from 'react-native-swag-styles'
 import { useDispatch, useSelector } from 'react-redux'
 import { Cell, Section } from '@/components/List'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import { SeasonalAsciiArtSection } from '@/components/SeasonalAsciiArtSection'
 import type { Layout, PrintData } from '@/print'
-import { selectLayouts } from '@/redux/modules/layout/selectors'
+import {
+  selectLayoutIsLoading,
+  selectLayouts,
+} from '@/redux/modules/layout/selectors'
 import { selectAllPrintData } from '@/redux/modules/printData/selectors'
 import { printLayout } from '@/redux/modules/printData/slice'
 import { printText } from '@/redux/modules/printer/slice'
@@ -18,6 +22,7 @@ import { PrintDataCell } from './PrintDataCell'
 
 type Props = {}
 type ComponentProps = Props & {
+  isLoading: boolean
   printData: PrintData[]
   layoutNames: Record<string, string>
   onPressText: (text: string) => void
@@ -28,6 +33,7 @@ type ComponentProps = Props & {
 }
 
 const Component: React.FC<ComponentProps> = ({
+  isLoading,
   printData,
   layoutNames,
   onPressText,
@@ -39,49 +45,52 @@ const Component: React.FC<ComponentProps> = ({
   const styles = useStyles()
 
   return (
-    <SafeScrollView style={styles.scrollView}>
-      <SeasonalAsciiArtSection />
-      <Section title="汎用印刷">
-        <InputDialogCell
-          title="テキストを印刷する"
-          dialogTitle="テキスト印刷"
-          dialogDescription="印刷するテキストを入力してください"
-          onSelectText={onPressText}
-        />
-        <Cell
-          title="その他"
-          onPress={onNavigateToPrinter}
-          accessory="disclosure"
-        />
-      </Section>
-      <Section title="レイアウト印刷">
-        {printData.length === 0 ? (
-          <Cell
-            title="印刷データがありません"
-            description="「レイアウトを管理する」から作成してください"
-            inactive={true}
+    <>
+      <SafeScrollView style={styles.scrollView}>
+        <SeasonalAsciiArtSection />
+        <Section title="汎用印刷">
+          <InputDialogCell
+            title="テキストを印刷する"
+            dialogTitle="テキスト印刷"
+            dialogDescription="印刷するテキストを入力してください"
+            onSelectText={onPressText}
           />
-        ) : (
-          printData.map((value) => (
-            <PrintDataCell
-              key={value.id}
-              printData={value}
-              layoutName={layoutNames[value.layoutId]}
-              onPressPrint={onPressPrintData}
-              onPressEdit={onPressEditPrintData}
+          <Cell
+            title="その他"
+            onPress={onNavigateToPrinter}
+            accessory="disclosure"
+          />
+        </Section>
+        <Section title="レイアウト印刷">
+          {printData.length === 0 ? (
+            <Cell
+              title="印刷データがありません"
+              description="「レイアウトを管理する」から作成してください"
+              inactive={true}
             />
-          ))
-        )}
-      </Section>
-      <Section title="レイアウト印刷のオプション">
-        <Cell
-          title="レイアウトを管理する"
-          description="レイアウトの作成・編集と、印刷データの入力"
-          onPress={onNavigateToLayoutList}
-          accessory="disclosure"
-        />
-      </Section>
-    </SafeScrollView>
+          ) : (
+            printData.map((value) => (
+              <PrintDataCell
+                key={value.id}
+                printData={value}
+                layoutName={layoutNames[value.layoutId]}
+                onPressPrint={onPressPrintData}
+                onPressEdit={onPressEditPrintData}
+              />
+            ))
+          )}
+        </Section>
+        <Section title="レイアウト印刷のオプション">
+          <Cell
+            title="レイアウトを管理する"
+            description="レイアウトの作成・編集と、印刷データの入力"
+            onPress={onNavigateToLayoutList}
+            accessory="disclosure"
+          />
+        </Section>
+      </SafeScrollView>
+      <LoadingSpinner isLoading={isLoading} />
+    </>
   )
 }
 
@@ -89,6 +98,7 @@ const Container: React.FC<Props> = (props) => {
   const navigation = useNavigation()
   const dispatch = useDispatch()
 
+  const isLoading = useSelector(selectLayoutIsLoading)
   const layouts: Layout[] = useSelector(selectLayouts)
   const printData: PrintData[] = useSelector(selectAllPrintData)
 
@@ -137,6 +147,7 @@ const Container: React.FC<Props> = (props) => {
     <Component
       {...props}
       {...{
+        isLoading,
         printData,
         layoutNames,
         onPressText,

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -1,6 +1,6 @@
-import { useIsFocused, useNavigation } from '@react-navigation/native'
+import { useNavigation } from '@react-navigation/native'
 import type React from 'react'
-import { useCallback, useEffect, useLayoutEffect, useMemo } from 'react'
+import { useCallback, useLayoutEffect, useMemo } from 'react'
 import { StyleSheet, type ViewStyle } from 'react-native'
 import { makeStyles } from 'react-native-swag-styles'
 import { useDispatch, useSelector } from 'react-redux'
@@ -8,11 +8,9 @@ import { Cell, Section } from '@/components/List'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import { SeasonalAsciiArtSection } from '@/components/SeasonalAsciiArtSection'
 import type { Layout, PrintData } from '@/print'
-import { selectDatabaseIsReady } from '@/redux/modules/database/selectors'
 import { selectLayouts } from '@/redux/modules/layout/selectors'
-import { fetchLayouts } from '@/redux/modules/layout/slice'
 import { selectAllPrintData } from '@/redux/modules/printData/selectors'
-import { fetchPrintData, printLayout } from '@/redux/modules/printData/slice'
+import { printLayout } from '@/redux/modules/printData/slice'
 import { printText } from '@/redux/modules/printer/slice'
 import { styleType } from '@/utils/styles'
 import { InputDialogCell } from './InputDialogCell'
@@ -90,11 +88,9 @@ const Component: React.FC<ComponentProps> = ({
 const Container: React.FC<Props> = (props) => {
   const navigation = useNavigation()
   const dispatch = useDispatch()
-  const isFocused = useIsFocused()
 
   const layouts: Layout[] = useSelector(selectLayouts)
   const printData: PrintData[] = useSelector(selectAllPrintData)
-  const isDatabaseReady = useSelector(selectDatabaseIsReady)
 
   const layoutNames = useMemo(
     () => Object.fromEntries(layouts.map((layout) => [layout.id, layout.name])),
@@ -104,14 +100,6 @@ const Container: React.FC<Props> = (props) => {
   useLayoutEffect(() => {
     navigation.setOptions({ title: 'モバイル印刷 for SUNMI' })
   }, [navigation])
-
-  // SQLite が情報源なので、表示するたびに読み直す
-  useEffect(() => {
-    if (isFocused && isDatabaseReady) {
-      dispatch(fetchLayouts())
-      dispatch(fetchPrintData())
-    }
-  }, [dispatch, isFocused, isDatabaseReady])
 
   const onPressText = useCallback(
     (text: string) => {

--- a/src/screens/LayoutList/index.tsx
+++ b/src/screens/LayoutList/index.tsx
@@ -8,10 +8,14 @@ import { useDispatch, useSelector } from 'react-redux'
 import { MESSAGE } from '@/CONSTANTS'
 import { InputDialog } from '@/components/Dialog'
 import { Cell, Section } from '@/components/List'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout } from '@/print'
 import { createLayout } from '@/print'
-import { selectLayouts } from '@/redux/modules/layout/selectors'
+import {
+  selectLayoutIsLoading,
+  selectLayouts,
+} from '@/redux/modules/layout/selectors'
 import {
   deleteLayout,
   duplicateLayout,
@@ -22,6 +26,7 @@ import { styleType } from '@/utils/styles'
 
 type Props = {}
 type ComponentProps = Props & {
+  isLoading: boolean
   layouts: Layout[]
   isDialogVisible: boolean
   onPressLayout: (layout: Layout) => void
@@ -32,6 +37,7 @@ type ComponentProps = Props & {
 }
 
 const Component: React.FC<ComponentProps> = ({
+  isLoading,
   layouts,
   isDialogVisible,
   onPressLayout,
@@ -73,6 +79,7 @@ const Component: React.FC<ComponentProps> = ({
           />
         </Section>
       </SafeScrollView>
+      <LoadingSpinner isLoading={isLoading} />
       <InputDialog
         isVisible={isDialogVisible}
         title="レイアウトの追加"
@@ -88,6 +95,7 @@ const Container: React.FC<Props> = (props) => {
   const navigation = useNavigation()
   const dispatch = useDispatch()
 
+  const isLoading = useSelector(selectLayoutIsLoading)
   const layouts = useSelector(selectLayouts)
 
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
@@ -157,6 +165,7 @@ const Container: React.FC<Props> = (props) => {
     <Component
       {...props}
       {...{
+        isLoading,
         layouts,
         isDialogVisible,
         onPressLayout,

--- a/src/screens/LayoutList/index.tsx
+++ b/src/screens/LayoutList/index.tsx
@@ -1,6 +1,6 @@
-import { useIsFocused, useNavigation } from '@react-navigation/native'
+import { useNavigation } from '@react-navigation/native'
 import type React from 'react'
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { useCallback, useLayoutEffect, useState } from 'react'
 import { StyleSheet, type ViewStyle } from 'react-native'
 import AlertAsync from 'react-native-alert-async'
 import { makeStyles } from 'react-native-swag-styles'
@@ -11,12 +11,10 @@ import { Cell, Section } from '@/components/List'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout } from '@/print'
 import { createLayout } from '@/print'
-import { selectDatabaseIsReady } from '@/redux/modules/database/selectors'
 import { selectLayouts } from '@/redux/modules/layout/selectors'
 import {
   deleteLayout,
   duplicateLayout,
-  fetchLayouts,
   saveLayout,
 } from '@/redux/modules/layout/slice'
 import { formatDateTime } from '@/utils/day'
@@ -89,23 +87,14 @@ const Component: React.FC<ComponentProps> = ({
 const Container: React.FC<Props> = (props) => {
   const navigation = useNavigation()
   const dispatch = useDispatch()
-  const isFocused = useIsFocused()
 
   const layouts = useSelector(selectLayouts)
-  const isDatabaseReady = useSelector(selectDatabaseIsReady)
 
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
 
   useLayoutEffect(() => {
     navigation.setOptions({ title: 'レイアウト' })
   }, [navigation])
-
-  // SQLite が情報源なので、表示するたびに読み直す
-  useEffect(() => {
-    if (isFocused && isDatabaseReady) {
-      dispatch(fetchLayouts())
-    }
-  }, [dispatch, isFocused, isDatabaseReady])
 
   const onPressLayout = useCallback(
     (layout: Layout) => {

--- a/src/screens/PrintDataList/index.tsx
+++ b/src/screens/PrintDataList/index.tsx
@@ -1,17 +1,10 @@
 import {
   type RouteProp,
-  useIsFocused,
   useNavigation,
   useRoute,
 } from '@react-navigation/native'
 import type React from 'react'
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import {
   StyleSheet,
   Text,
@@ -29,13 +22,11 @@ import { Cell, Section } from '@/components/List'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, PrintData } from '@/print'
 import { createPrintData } from '@/print'
-import { selectDatabaseIsReady } from '@/redux/modules/database/selectors'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
 import { selectPrintDataByLayoutId } from '@/redux/modules/printData/selectors'
 import {
   deletePrintData,
   duplicatePrintData,
-  fetchPrintData,
   printLayout,
   savePrintData,
 } from '@/redux/modules/printData/slice'
@@ -126,7 +117,6 @@ const Component: React.FC<ComponentProps> = ({
 const Container: React.FC<Props> = (props) => {
   const navigation = useNavigation()
   const dispatch = useDispatch()
-  const isFocused = useIsFocused()
 
   const {
     params: { layoutId },
@@ -139,19 +129,12 @@ const Container: React.FC<Props> = (props) => {
   )
   const layout = useSelector(layoutSelector)
   const printData = useSelector(printDataSelector)
-  const isDatabaseReady = useSelector(selectDatabaseIsReady)
 
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
 
   useLayoutEffect(() => {
     navigation.setOptions({ title: '印刷データ' })
   }, [navigation])
-
-  useEffect(() => {
-    if (isFocused && isDatabaseReady) {
-      dispatch(fetchPrintData())
-    }
-  }, [dispatch, isFocused, isDatabaseReady])
 
   const onPressPrintData = useCallback(
     (value: PrintData) => {

--- a/src/screens/PrintDataList/index.tsx
+++ b/src/screens/PrintDataList/index.tsx
@@ -19,11 +19,15 @@ import { useDispatch, useSelector } from 'react-redux'
 import { COLOR, MESSAGE } from '@/CONSTANTS'
 import { InputDialog } from '@/components/Dialog'
 import { Cell, Section } from '@/components/List'
+import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, PrintData } from '@/print'
 import { createPrintData } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
-import { selectPrintDataByLayoutId } from '@/redux/modules/printData/selectors'
+import {
+  selectPrintDataByLayoutId,
+  selectPrintDataIsLoading,
+} from '@/redux/modules/printData/selectors'
 import {
   deletePrintData,
   duplicatePrintData,
@@ -38,6 +42,7 @@ type ParamsProps = RouteProp<MainParams, 'PrintDataList'>
 
 type Props = {}
 type ComponentProps = Props & {
+  isLoading: boolean
   layout: Layout | undefined
   printData: PrintData[]
   isDialogVisible: boolean
@@ -49,6 +54,7 @@ type ComponentProps = Props & {
 }
 
 const Component: React.FC<ComponentProps> = ({
+  isLoading,
   layout,
   printData,
   isDialogVisible,
@@ -103,6 +109,7 @@ const Component: React.FC<ComponentProps> = ({
           />
         </Section>
       </SafeScrollView>
+      <LoadingSpinner isLoading={isLoading} />
       <InputDialog
         isVisible={isDialogVisible}
         title="印刷データの追加"
@@ -129,6 +136,7 @@ const Container: React.FC<Props> = (props) => {
   )
   const layout = useSelector(layoutSelector)
   const printData = useSelector(printDataSelector)
+  const isLoading = useSelector(selectPrintDataIsLoading)
 
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
 
@@ -208,6 +216,7 @@ const Container: React.FC<Props> = (props) => {
     <Component
       {...props}
       {...{
+        isLoading,
         layout,
         printData,
         isDialogVisible,


### PR DESCRIPTION
> [!NOTE]
> [#479](https://github.com/mitsuharu/mobile-printer/pull/479) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

画面遷移が遅い件です。**まず実機で計測しました。**

| 操作 | レイアウト読み込み | 印刷データ読み込み |
| --- | --- | --- |
| 起動直後のホーム | 563ms | 782ms |
| レイアウト一覧へ移動 | 203ms | － |
| ホームへ戻る | 123ms | 323ms |

**画面を開くたびに SQLite を読み直しており、その待ちが遷移のたびに乗っていました。** 端末のスペックだけの問題ではありませんでした。

## 1. 読み込みを起動時の一度だけにする

SQLite を情報源にしているため、画面を表示するたびに読み直す作りにしていました。ただし**書き込みはすべて saga を通り、そのたびに写しを作り直しています。** アプリの外からデータが変わることはないので、読み込みは起動時の一度で足ります。

起動時（データベースの初期化とプリセット投入のあと）に一度読み込み、画面ごとの読み直しをやめました。

**計測し直したところ、画面遷移での読み込みは0回になりました**（起動時の 218ms + 308ms のみ）。

## 2. 読み込み中のインジケーター

読み込み中は画面が空のままで、待っているのか何もないのかが分かりませんでした。一覧の画面（ホーム／レイアウト一覧／印刷データ一覧）で、既存の `LoadingSpinner` を表示するようにしました。

## 残る遅さについて

上記で DB 由来の待ちは無くなりますが、**画面遷移そのものの体感速度は debug ビルドの影響が大きい**と思われます。debug は JS を Metro から読み、最適化もされていません。リリースビルド（`./gradlew assembleRelease`）ではかなり速くなるはずなので、気になる場合はそちらでも確認していただけると切り分けできます。

さらに詰めるなら、一覧の読み込みで画像の Base64（サンプルのアイコンは約118KB）まで読んでいる点が次の候補です。一覧では画像の中身は不要なので、印刷やプレビューのときだけ読む形にできます。ただし型と読み込み経路の変更が要るため、本PRには含めていません。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 232 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- 一時的な計測ログで、画面遷移のたびに読み込みが走っていたことを確認（上表）
- 修正後、レイアウト一覧への往復を2回繰り返しても読み込みが起動時の1回だけであることを確認
- `pm clear` 後の初回起動でも、プリセット投入のあと一覧が正しく表示される
- 計測ログは本PRに含めていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
