### PR TITLE
fix(print): 区切り線をレイアウトで指定したときだけ印刷する

### DIFF
--- a/src/print/__test__/presets.test.ts
+++ b/src/print/__test__/presets.test.ts
@@ -153,8 +153,17 @@ describe('createPresets の印刷内容', () => {
       command.type === 'lineWrap' ? [{ index, count: command.count }] : [],
     )
 
-    // 冒頭・画像の前後・QRコードの前・QRコードと印刷時刻の間・末尾の紙送り
-    expect(blanks.map(({ count }) => count)).toEqual([1, 1, 2, 1, 2, 3])
+    // 冒頭・画像の前後・各まとまりの前・QRコードの前後・末尾の紙送り
+    expect(blanks.map(({ count }) => count)).toEqual([
+      1, 1, 2, 1, 1, 1, 1, 2, 3,
+    ])
+  })
+
+  it('区切り線は入れない', () => {
+    // 区切り線は利用者がレイアウトで足すもので、初期状態では出さない
+    expect(
+      commandsFor('サンプル').some((command) => command.type === 'printHR'),
+    ).toBe(false)
   })
 
   it('アイコン画像とQRコードを出力する', () => {

--- a/src/print/presets/index.ts
+++ b/src/print/presets/index.ts
@@ -81,12 +81,6 @@ const spacer = (lines: number): LayoutElement => ({
   lines,
 })
 
-const divider = (): LayoutElement => ({
-  id: createUUID(),
-  type: 'divider',
-  barType: 'line',
-})
-
 /**
  * 名刺レイアウトと、その入力項目のIDを作る
  *
@@ -125,18 +119,19 @@ const createProfileLayout = (): {
     spacer(2),
     centeredText(fieldIds.description, FONT_SIZE.DEFAULT),
 
-    divider(),
+    // 区切り線は利用者がレイアウトで足すものとし、ここでは行を空けるだけにする
+    spacer(1),
     centeredText(fieldIds.company, FONT_SIZE.DEFAULT),
     centeredText(fieldIds.position, FONT_SIZE.DEFAULT),
     centeredText(fieldIds.address, FONT_SIZE.DEFAULT),
 
-    divider(),
+    spacer(1),
     snsColumns('X:', fieldIds.twitter),
     snsColumns('Facebook:', fieldIds.facebook),
     snsColumns('GitHub:', fieldIds.github),
     snsColumns('Website:', fieldIds.website),
 
-    divider(),
+    spacer(1),
     centeredText(fieldIds.qrDescription, FONT_SIZE.DEFAULT),
     spacer(1),
     {


### PR DESCRIPTION
> [!NOTE]
> [#481](https://github.com/mitsuharu/mobile-printer/pull/481) の上に積んだスタックPRです。まとめPRは [#463](https://github.com/mitsuharu/mobile-printer/pull/463) です。

## 概要

初期状態で区切り線が印刷される件です。

原因は**プリセットの名刺レイアウトに区切り線の要素を3つ入れていた**ことでした（会社名の前・SNSの前・QRコードの前）。従来のプロフィール印刷を忠実に再現した結果です。印刷経路には区切り線を強制する処理はなく、`buildPrintCommands` は `divider` 要素があるときだけ `printHR` を出します。

区切り線は利用者がレイアウトへ足すものとし、プリセットからは外しました。

## 空行への置き換えについて

**区切り線はまとまりの切れ目も兼ねていたため、そのまま消すと各ブロックが詰まります。** 代わりに1行空けるようにしました。区切り線が欲しい場合は、レイアウト編集画面から要素として追加できます。

「空行も不要で、詰めたままでよい」ということであれば、その空行も外します。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 238 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

プリセットが `printHR` を出さないことと、空行の位置・行数をテストで固定しています。

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

`pm clear` でデータを消し、まっさらな状態から確認しました。

- プレビューで区切り線が表示されず、各まとまりが1行の空白で区切られている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
