### PR TITLE
feat(layout): 入力項目を選ぶ場で追加できるようにする

### DIFF
--- a/src/components/Modal/ListPickerModal/index.tsx
+++ b/src/components/Modal/ListPickerModal/index.tsx
@@ -21,11 +21,29 @@ export type ListPickerItem<T> = {
   description?: string
 }
 
+/**
+ * 一覧の末尾に置く操作
+ *
+ * 選択肢そのものを増やしたいときに使う。
+ */
+export type ListPickerAction = {
+  title: string
+  description?: string
+  onPress: () => void
+}
+
 type Props<T> = {
   visible: boolean
   title: string
+
+  /**
+   * 一覧の上に添える説明
+   */
+  description?: string
+
   items: ListPickerItem<T>[]
   selected?: T
+  action?: ListPickerAction
   onSelect: (value: T) => void
   onCancel: () => void
 }
@@ -40,8 +58,10 @@ type Props<T> = {
 export const ListPickerModal = <T,>({
   visible,
   title,
+  description,
   items,
   selected,
+  action,
   onSelect,
   onCancel,
 }: Props<T>): React.ReactElement => {
@@ -57,6 +77,9 @@ export const ListPickerModal = <T,>({
       <View style={styles.container}>
         <View style={styles.modal}>
           <Text style={styles.title}>{title}</Text>
+          {!!description && (
+            <Text style={styles.description}>{description}</Text>
+          )}
           <ScrollView style={styles.list}>
             {items.map((item) => (
               <Cell
@@ -67,6 +90,13 @@ export const ListPickerModal = <T,>({
                 accessory={item.value === selected ? 'check' : 'disclosure'}
               />
             ))}
+            {!!action && (
+              <Cell
+                title={action.title}
+                description={action.description}
+                onPress={action.onPress}
+              />
+            )}
           </ScrollView>
           <Button
             onPress={onCancel}
@@ -97,10 +127,17 @@ const useStyles = makeStyles(useColorScheme, (colorScheme) => {
     }),
     title: styleType<TextStyle>({
       paddingHorizontal: 16,
-      paddingVertical: 16,
+      paddingTop: 16,
+      paddingBottom: 8,
       fontSize: 18,
       fontWeight: 'bold',
       color: COLOR(colorScheme).TEXT.PRIMARY,
+    }),
+    description: styleType<TextStyle>({
+      paddingHorizontal: 16,
+      paddingBottom: 8,
+      fontSize: 12,
+      color: COLOR(colorScheme).TEXT.SECONDARY,
     }),
     list: styleType<ViewStyle>({
       flexGrow: 0,

--- a/src/screens/ElementEditor/ImageSourceSection.tsx
+++ b/src/screens/ElementEditor/ImageSourceSection.tsx
@@ -1,10 +1,12 @@
 import type React from 'react'
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { StyleSheet, View, type ViewStyle } from 'react-native'
 import { BASE64 } from '@/CONSTANTS'
+import { InputDialog } from '@/components/Dialog'
 import { ImageFileView } from '@/components/ImageFileView'
-import { Cell, Section } from '@/components/List'
-import type { ImageSource, Layout } from '@/print'
+import { Section } from '@/components/List'
+import type { ImageSource, Layout, LayoutField } from '@/print'
+import { createLayoutField } from '@/print'
 import { copyImageFile } from '@/utils/imageStore'
 import { styleType } from '@/utils/styles'
 import { createUUID } from '@/utils/uuid'
@@ -14,7 +16,12 @@ type Props = {
   layout: Layout
   source: ImageSource
   width: number
-  onChange: (source: ImageSource) => void
+  /**
+   * 供給元を変える
+   *
+   * その場で作った入力項目は、要素の変更と一緒に保存するため `field` で渡す。
+   */
+  onChange: (source: ImageSource, field?: LayoutField) => void
 }
 
 type SourceKind = ImageSource['kind']
@@ -28,6 +35,22 @@ export const ImageSourceSection: React.FC<Props> = ({
   width,
   onChange,
 }) => {
+  const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
+
+  const onSubmitNewField = useCallback(
+    (label: string) => {
+      setIsDialogVisible(false)
+      const trimmed = label.trim()
+      const field = createLayoutField({
+        label: trimmed || '入力項目',
+        key: trimmed || `field${layout.fields.length + 1}`,
+        valueType: 'image',
+      })
+      onChange({ kind: 'field', fieldId: field.id }, field)
+    },
+    [layout.fields.length, onChange],
+  )
+
   const onChangeKind = useCallback(
     (kind: SourceKind) => {
       if (kind === source.kind) {
@@ -82,24 +105,31 @@ export const ImageSourceSection: React.FC<Props> = ({
         <View style={styles.imageView}>
           <ImageFileView path={source.asset?.path} onChange={onChangeImage} />
         </View>
-      ) : layout.fields.length === 0 ? (
-        <Cell
-          title="入力項目がありません"
-          description="レイアウトの「入力項目」から追加してください"
-          inactive={true}
-        />
       ) : (
         <PickerCell
           title="入力項目"
+          description="印刷データごとに入力する箇所です"
           value={source.fieldId}
           items={layout.fields.map((field) => ({
             value: field.id,
             title: field.label || field.key,
             description: field.key,
           }))}
+          action={{
+            title: '入力項目を追加する',
+            description: 'このレイアウトに新しい入力欄を作ります',
+            onPress: () => setIsDialogVisible(true),
+          }}
           onChange={(fieldId) => onChange({ kind: 'field', fieldId })}
         />
       )}
+      <InputDialog
+        isVisible={isDialogVisible}
+        title="入力項目の追加"
+        description="表示名を入力してください"
+        onPress={onSubmitNewField}
+        onCancel={() => setIsDialogVisible(false)}
+      />
     </Section>
   )
 }

--- a/src/screens/ElementEditor/TextSourceSection.tsx
+++ b/src/screens/ElementEditor/TextSourceSection.tsx
@@ -1,14 +1,22 @@
 import type React from 'react'
-import { useCallback } from 'react'
-import { Cell, Section } from '@/components/List'
-import type { Layout, TextSource } from '@/print'
+import { useCallback, useState } from 'react'
+import { InputDialog } from '@/components/Dialog'
+import { Section } from '@/components/List'
+import type { Layout, LayoutField, TextSource } from '@/print'
+import { createLayoutField } from '@/print'
 import { PickerCell, TextValueCell } from './rows'
 
 type Props = {
   title: string
   layout: Layout
   source: TextSource
-  onChange: (source: TextSource) => void
+
+  /**
+   * 供給元を変える
+   *
+   * その場で作った入力項目は、要素の変更と一緒に保存するため `field` で渡す。
+   */
+  onChange: (source: TextSource, field?: LayoutField) => void
 }
 
 type SourceKind = TextSource['kind']
@@ -22,6 +30,21 @@ export const TextSourceSection: React.FC<Props> = ({
   source,
   onChange,
 }) => {
+  const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
+
+  const onSubmitNewField = useCallback(
+    (label: string) => {
+      setIsDialogVisible(false)
+      const trimmed = label.trim()
+      const field = createLayoutField({
+        label: trimmed || '入力項目',
+        key: trimmed || `field${layout.fields.length + 1}`,
+      })
+      onChange({ kind: 'field', fieldId: field.id }, field)
+    },
+    [layout.fields.length, onChange],
+  )
+
   const onChangeKind = useCallback(
     (kind: SourceKind) => {
       if (kind === source.kind) {
@@ -61,24 +84,31 @@ export const TextSourceSection: React.FC<Props> = ({
           value={source.value}
           onChange={(value) => onChange({ kind: 'static', value })}
         />
-      ) : layout.fields.length === 0 ? (
-        <Cell
-          title="入力項目がありません"
-          description="レイアウトの「入力項目」から追加してください"
-          inactive={true}
-        />
       ) : (
         <PickerCell
           title="入力項目"
+          description="印刷データごとに入力する箇所です"
           value={source.fieldId}
           items={layout.fields.map((field) => ({
             value: field.id,
             title: field.label || field.key,
             description: field.key,
           }))}
+          action={{
+            title: '入力項目を追加する',
+            description: 'このレイアウトに新しい入力欄を作ります',
+            onPress: () => setIsDialogVisible(true),
+          }}
           onChange={(fieldId) => onChange({ kind: 'field', fieldId })}
         />
       )}
+      <InputDialog
+        isVisible={isDialogVisible}
+        title="入力項目の追加"
+        description="表示名を入力してください"
+        onPress={onSubmitNewField}
+        onCancel={() => setIsDialogVisible(false)}
+      />
     </Section>
   )
 }

--- a/src/screens/ElementEditor/index.tsx
+++ b/src/screens/ElementEditor/index.tsx
@@ -19,8 +19,8 @@ import { useDispatch, useSelector } from 'react-redux'
 import { BASE64, COLOR, MESSAGE } from '@/CONSTANTS'
 import { Cell, Section } from '@/components/List'
 import { SafeScrollView } from '@/components/SafeScrollView'
-import type { Layout, LayoutElement } from '@/print'
-import { removeElement, replaceElement } from '@/print'
+import type { Layout, LayoutElement, LayoutField } from '@/print'
+import { removeElement, replaceElement, upsertField } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
 import { saveLayout } from '@/redux/modules/layout/slice'
 import type { MainParams } from '@/routes/main.params'
@@ -44,7 +44,13 @@ type Props = {}
 type ComponentProps = Props & {
   layout: Layout | undefined
   element: LayoutElement | undefined
-  onChange: (element: LayoutElement) => void
+  /**
+   * 要素を差し替える
+   *
+   * 供給元の編集でその場で作った入力項目は `field` で受け取り、
+   * 要素の変更と同じ保存へまとめる。別々に保存すると片方が失われる。
+   */
+  onChange: (element: LayoutElement, field?: LayoutField) => void
   onDelete: () => void
 }
 
@@ -86,7 +92,9 @@ const Component: React.FC<ComponentProps> = ({
             title="内容"
             layout={layout}
             source={element.source}
-            onChange={(source) => onChange({ ...element, source })}
+            onChange={(source, field) =>
+              onChange({ ...element, source }, field)
+            }
           />
           <Section title="体裁">
             <PickerCell
@@ -126,7 +134,9 @@ const Component: React.FC<ComponentProps> = ({
             layout={layout}
             source={element.source}
             width={element.width}
-            onChange={(source) => onChange({ ...element, source })}
+            onChange={(source, field) =>
+              onChange({ ...element, source }, field)
+            }
           />
           <Section title="体裁">
             <NumberValueCell
@@ -160,7 +170,9 @@ const Component: React.FC<ComponentProps> = ({
             title="内容"
             layout={layout}
             source={element.source}
-            onChange={(source) => onChange({ ...element, source })}
+            onChange={(source, field) =>
+              onChange({ ...element, source }, field)
+            }
           />
           <Section title="体裁">
             <NumberValueCell
@@ -194,13 +206,16 @@ const Component: React.FC<ComponentProps> = ({
               title={`${index + 1}列目`}
               layout={layout}
               source={column.source}
-              onChange={(source) =>
-                onChange({
-                  ...element,
-                  columns: element.columns.map((value, i) =>
-                    i === index ? { ...value, source } : value,
-                  ),
-                })
+              onChange={(source, field) =>
+                onChange(
+                  {
+                    ...element,
+                    columns: element.columns.map((value, i) =>
+                      i === index ? { ...value, source } : value,
+                    ),
+                  },
+                  field,
+                )
               }
             />
             <Section>
@@ -342,11 +357,12 @@ const Container: React.FC<Props> = (props) => {
   }, [navigation, element])
 
   const onChange = useCallback(
-    (next: LayoutElement) => {
+    (next: LayoutElement, field?: LayoutField) => {
       if (!layout) {
         return
       }
-      dispatch(saveLayout(replaceElement(layout, next)))
+      const base = field ? upsertField(layout, field) : layout
+      dispatch(saveLayout(replaceElement(base, next)))
     },
     [dispatch, layout],
   )

--- a/src/screens/ElementEditor/rows/PickerCell.tsx
+++ b/src/screens/ElementEditor/rows/PickerCell.tsx
@@ -2,14 +2,22 @@ import type React from 'react'
 import { useCallback, useState } from 'react'
 import { Cell } from '@/components/List'
 import {
+  type ListPickerAction,
   type ListPickerItem,
   ListPickerModal,
 } from '@/components/Modal/ListPickerModal'
 
 type Props<T> = {
   title: string
+  description?: string
   value: T
   items: ListPickerItem<T>[]
+
+  /**
+   * 一覧の末尾に置く操作
+   */
+  action?: ListPickerAction
+
   onChange: (value: T) => void
 }
 
@@ -18,8 +26,10 @@ type Props<T> = {
  */
 export const PickerCell = <T,>({
   title,
+  description,
   value,
   items,
+  action,
   onChange,
 }: Props<T>): React.ReactElement => {
   const [isVisible, setIsVisible] = useState<boolean>(false)
@@ -44,8 +54,18 @@ export const PickerCell = <T,>({
       <ListPickerModal
         visible={isVisible}
         title={title}
+        description={description}
         items={items}
         selected={value}
+        action={
+          action && {
+            ...action,
+            onPress: () => {
+              setIsVisible(false)
+              action.onPress()
+            },
+          }
+        }
         onSelect={onSelect}
         onCancel={() => setIsVisible(false)}
       />

--- a/src/screens/LayoutFields/index.tsx
+++ b/src/screens/LayoutFields/index.tsx
@@ -73,11 +73,18 @@ const Component: React.FC<ComponentProps> = ({
           入力項目は、印刷データごとに内容を変えたい箇所です。要素の「内容の決め方」で
           「印刷データごとに入力する」を選ぶと、ここで作った入力項目を指定できます。
         </Text>
+        <Section>
+          <Cell
+            title="入力項目を追加する"
+            description="表示名・キー・入力の種類は、追加したあとに変更できます"
+            onPress={onPressAdd}
+          />
+        </Section>
         {layout.fields.length === 0 ? (
           <Section title="入力項目">
             <Cell
               title="入力項目がありません"
-              description="下の「入力項目を追加する」から作成してください"
+              description="上の「入力項目を追加する」から作成してください"
               inactive={true}
             />
           </Section>
@@ -108,9 +115,6 @@ const Component: React.FC<ComponentProps> = ({
             </Section>
           ))
         )}
-        <Section title="操作">
-          <Cell title="入力項目を追加する" onPress={onPressAdd} />
-        </Section>
       </SafeScrollView>
       <InputDialog
         isVisible={isDialogVisible}


### PR DESCRIPTION
> [!NOTE]
> [#483](https://github.com/mitsuharu/mobile-printer/pull/483) とは独立した変更です。どちらから先にマージしても構いません。

## 概要

「テキスト要素で選べる入力項目の種類は増やせないのか」というご指摘への対応です。

**増やすことはできました**が、追加する場所がレイアウト編集画面の奥（入力項目 → 一覧の最下部）にあり、**選ぶ画面からはそこへ行けず、増やせること自体に気づけない**状態でした。

## 変更

### 1. 選ぶ場で追加できるようにする

要素の供給元で入力項目を選ぶ一覧の末尾に **「入力項目を追加する」** を置きました。表示名を入れるとその場で作られ、**そのまま選択済みになります。** レイアウト編集画面まで戻る必要がありません。

あわせて、一覧の見出しに「印刷データごとに入力する箇所です」という説明を添えました。

**追加した入力項目は、要素の変更と同じ保存へまとめています。** 別々に保存すると、どちらも同じレイアウトを元に組み立てるため片方が失われます。実機で、新しい項目のIDが要素の `source` と一致することを確認しました。

### 2. 入力項目の画面の「追加する」を上部へ

一覧の下にあって気づきにくかったため、**説明を添えて上部へ移しました**（「表示名・キー・入力の種類は、追加したあとに変更できます」）。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 211 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- テキスト要素の入力項目の一覧に説明が出て、末尾に「入力項目を追加する」が並ぶ
- そこから表示名を入れて追加すると、`layout_fields` が13件から14件になる
- **追加した入力項目のIDが、その要素の `source` の `fieldId` と一致する**（追加と選択が1回の保存で反映されている）
- レイアウト編集画面の「入力項目」が「14個」に更新される
- 入力項目の画面で「入力項目を追加する」が説明つきで上部に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
