### PR TITLE
fix(layout): テキスト入力で改行できるようにする

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -29,6 +29,11 @@ type Props = {
 
   keyboardType?: KeyboardTypeOptions
 
+  /**
+   * 改行を入れられるようにするか
+   */
+  multiline?: boolean
+
   onCancel?: () => void
   onPress?: (text: string) => void
 }
@@ -46,6 +51,7 @@ const Component: React.FC<ComponentProps> = ({
   description,
   defaultValue,
   keyboardType,
+  multiline,
   keyboardHeight,
   onChangeText,
   onSubmit,
@@ -72,13 +78,15 @@ const Component: React.FC<ComponentProps> = ({
             <Text style={styles.description}>{description}</Text>
           )}
           <TextInput
-            style={styles.input}
+            style={[styles.input, multiline && styles.multilineInput]}
             defaultValue={defaultValue}
             onChangeText={onChangeText}
             keyboardType={keyboardType ?? 'default'}
             autoCapitalize="none"
             autoFocus={true}
             underlineColorAndroid="transparent"
+            multiline={multiline}
+            textAlignVertical={multiline ? 'top' : 'center'}
           />
           <View style={styles.footer}>
             <Button
@@ -180,6 +188,10 @@ const useStyles = makeStyles(useColorScheme, (colorScheme) => {
       color: COLOR(colorScheme).TEXT.PRIMARY,
       borderBottomWidth: StyleSheet.hairlineWidth,
       borderBottomColor: COLOR(colorScheme).TEXT.SECONDARY,
+    }),
+    multilineInput: styleType<TextStyle>({
+      minHeight: 96,
+      maxHeight: 160,
     }),
     footer: styleType<ViewStyle>({
       flexDirection: 'row',

--- a/src/screens/ElementEditor/TextSourceSection.tsx
+++ b/src/screens/ElementEditor/TextSourceSection.tsx
@@ -59,6 +59,8 @@ export const TextSourceSection: React.FC<Props> = ({
         <TextValueCell
           title="内容"
           value={source.value}
+          dialogDescription="改行して複数行にできます"
+          multiline={true}
           onChange={(value) => onChange({ kind: 'static', value })}
         />
       ) : layout.fields.length === 0 ? (

--- a/src/screens/ElementEditor/rows/TextValueCell.tsx
+++ b/src/screens/ElementEditor/rows/TextValueCell.tsx
@@ -22,6 +22,12 @@ type Props = {
   placeholder?: string
   dialogDescription?: string
   keyboardType?: KeyboardTypeOptions
+
+  /**
+   * 改行を入れられるようにするか
+   */
+  multiline?: boolean
+
   onChange: (value: string) => void
 }
 
@@ -35,6 +41,7 @@ export const TextValueCell: React.FC<Props> = ({
   placeholder,
   dialogDescription,
   keyboardType,
+  multiline,
   onChange,
 }) => {
   const [isVisible, setIsVisible] = useState<boolean>(false)
@@ -64,6 +71,7 @@ export const TextValueCell: React.FC<Props> = ({
         description={dialogDescription}
         defaultValue={value}
         keyboardType={keyboardType}
+        multiline={multiline}
         onPress={onSubmit}
         onCancel={onCancel}
       />

--- a/src/screens/PrintDataForm/index.tsx
+++ b/src/screens/PrintDataForm/index.tsx
@@ -107,6 +107,7 @@ const Component: React.FC<ComponentProps> = ({
                 title={field.label || field.key}
                 value={textValueOf(printData.values[field.id])}
                 keyboardType={field.valueType === 'url' ? 'url' : 'default'}
+                multiline={field.valueType === 'multilineText'}
                 onChange={(value) =>
                   onChangeValue(field, { kind: 'text', value })
                 }


### PR DESCRIPTION
> [!NOTE]
> [#483](https://github.com/mitsuharu/mobile-printer/pull/483) / [#484](https://github.com/mitsuharu/mobile-printer/pull/484) とは独立した変更です。順不同でマージできます。

## 概要

テキスト入力のダイアログで改行できるようにします。

調べたところ、**入力の種類に「複数行テキスト」がありながら、入力欄が1行だったため、実際には改行を入れられませんでした。** 種類として存在するのに使えない状態だったので、不具合の修正にあたります。

## 変更

- `InputDialog` に `multiline` を追加（複数行のときは入力欄を高くし、上揃えにする）
- 印刷データの入力欄で、入力の種類が **複数行テキスト** の項目を複数行にする
- 要素の「レイアウトに直接書く」テキストも複数行にする（「改行して複数行にできます」と説明を添える）

従来のテキスト入力と同じダイアログのまま、複数行のときだけ入力欄を広げる形にしました。**別のインタフェースでもよいとのことでしたが、レシートは1行32文字と短いため、専用画面を挟むほどではないと判断しました。** 実機で3行入れても窮屈さはありませんでした。長文で使いにくいようなら、全画面の編集画面へ切り替えます。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 211 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

「フリーテキスト」（複数行テキスト）で通しで確認しました。

- ダイアログの入力欄が複数行になり、キーボードの改行キーで行を追加できる
- 確定すると SQLite に改行を含んだまま保存される（`'人間五十年、…\nせこんｄ＿ぃね'`）
- プレビューで改行が反映される
- 「この内容で印刷する」がエラーなく実行され、**紙でも改行されて印刷されることをメンテナーが目視で確認済み**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

