### PR TITLE
fix(printData): 印刷データの名前を「印刷データ名」に呼び分ける

### DIFF
--- a/src/screens/PrintDataForm/index.tsx
+++ b/src/screens/PrintDataForm/index.tsx
@@ -72,8 +72,11 @@ const Component: React.FC<ComponentProps> = ({
   return (
     <SafeScrollView style={styles.scrollView}>
       <Section title="印刷データ">
+        {/*
+          入力項目にも「名前」が並ぶため、ここは「印刷データ名」と呼び分ける
+        */}
         <TextValueCell
-          title="名前"
+          title="印刷データ名"
           value={printData.title}
           dialogDescription="一覧に表示する名前です"
           onChange={onChangeTitle}

--- a/src/screens/PrintDataList/index.tsx
+++ b/src/screens/PrintDataList/index.tsx
@@ -113,7 +113,7 @@ const Component: React.FC<ComponentProps> = ({
       <InputDialog
         isVisible={isDialogVisible}
         title="印刷データの追加"
-        description="名前を入力してください"
+        description="印刷データ名を入力してください"
         onPress={onSubmitTitle}
         onCancel={onCancelDialog}
       />


### PR DESCRIPTION
> [!NOTE]
> [#483](https://github.com/mitsuharu/mobile-printer/pull/483) / [#484](https://github.com/mitsuharu/mobile-printer/pull/484) / [#485](https://github.com/mitsuharu/mobile-printer/pull/485) とは独立した変更です。順不同でマージできます。

## 概要

印刷データの編集画面で、**印刷データそのものの名前と、入力項目の「名前」が、どちらも「名前」と表示されていて紛らわしい**というご指摘への対応です。

プリセットの名刺レイアウトには「名前」という入力項目があるため、次のように並んでいました。

```
[印刷データ]
  名前 / サンプル      ← 印刷データそのものの名前
[入力]
  名前 / 織田信長      ← 入力項目の「名前」
```

印刷データ側を **「印刷データ名」** と呼び分けました。あわせて、印刷データを追加するときのダイアログの説明も「印刷データ名を入力してください」に揃えています。

## ラベルを残した理由

「この一覧ではデータ名の表示だけでよいのでは」ともいただきましたが、**ラベルは残しました。**

- 画面上部（ナビゲーションバー）にはすでにデータ名が出ているため、値だけを置くと**同じ文字が2つ並ぶ**見え方になります
- このセルはタップして名前を変える操作を持っており、ラベルがないと**編集できることが分かりにくい**と考えました

ラベルなしのほうがよければ、値だけのセルに変更します。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 211 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- 印刷データの編集画面で「印刷データ名 / サンプル」と「名前 / 織田信長」が区別できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
