### PR TITLE
feat(preview): プレビューに実際の印刷と異なる旨の注意を入れる

### DIFF
--- a/src/screens/LayoutPreview/index.tsx
+++ b/src/screens/LayoutPreview/index.tsx
@@ -69,6 +69,10 @@ const Component: React.FC<ComponentProps> = ({
       edges={['bottom']}
       onLayout={onLayout}
     >
+      <Text style={styles.notice}>
+        これは画面上のイメージです。実際の印刷結果とは、文字の形や行の詰まり方が
+        異なることがあります。
+      </Text>
       <Text style={styles.description}>
         用紙の幅 {paperPixelWidth}px で描いています。
         {isPlaceholder ? '入力項目は表示名を仮の値として入れています。' : null}
@@ -169,9 +173,16 @@ const useStyles = makeStyles(useColorScheme, (colorScheme) => {
       padding: HORIZONTAL_PADDING,
       alignItems: 'flex-start',
     }),
-    description: styleType<TextStyle>({
+    notice: styleType<TextStyle>({
       paddingHorizontal: HORIZONTAL_PADDING,
       paddingTop: 12,
+      fontSize: 12,
+      fontWeight: 'bold',
+      color: COLOR(colorScheme).TEXT.PRIMARY,
+    }),
+    description: styleType<TextStyle>({
+      paddingHorizontal: HORIZONTAL_PADDING,
+      paddingTop: 4,
       fontSize: 12,
       color: COLOR(colorScheme).TEXT.SECONDARY,
     }),


### PR DESCRIPTION
> [!NOTE]
> [#483](https://github.com/mitsuharu/mobile-printer/pull/483) / [#484](https://github.com/mitsuharu/mobile-printer/pull/484) / [#485](https://github.com/mitsuharu/mobile-printer/pull/485) / [#486](https://github.com/mitsuharu/mobile-printer/pull/486) とは独立した変更です。順不同でマージできます。

## 概要

印刷イメージの画面に、実際の印刷結果と異なる場合がある旨の注意を追加します。

```
これは画面上のイメージです。実際の印刷結果とは、文字の形や行の詰まり方が
異なることがあります。
```

これまでの説明文（用紙の幅、仮の値の扱い）はその下に残し、注意のほうを目立たせています。

## 文面について

「異なることがあります」と幅を持たせ、**具体的に何がずれるか**（文字の形、行の詰まり方）を書きました。プレビューは端末の等幅フォントで描いており、字送りはプリンターに合わせて換算していますが、**書体そのものはプリンター内蔵フォントと同じではありません。** 要素の並びや寄せ、1行に入る文字数は一致します。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 211 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- プレビュー画面の上部に注意が表示され、その下に従来の説明が続く

🤖 Generated with [Claude Code](https://claude.com/claude-code)
