### PR TITLE
fix(ui): 入力ダイアログでキーボードが出ないことがあるのを直す

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   Text,
   TextInput,
+  type TextInputInstance,
   type TextStyle,
   useColorScheme,
   View,
@@ -16,6 +17,19 @@ import { makeStyles } from 'react-native-swag-styles'
 import { COLOR, MESSAGE } from '@/CONSTANTS'
 import { Button } from '@/components/Button'
 import { styleType } from '@/utils/styles'
+
+/**
+ * Modal が表示され切ってから入力欄へフォーカスするまでの待ち時間
+ */
+const FOCUS_DELAY = 100
+
+/**
+ * キーボードが出なかったときに、フォーカスを当て直す間隔と回数
+ *
+ * 1回では出ないことがあるため、出るまで数回試す。
+ */
+const FOCUS_INTERVAL = 200
+const FOCUS_MAX_ATTEMPTS = 5
 
 type Props = {
   title?: string
@@ -59,12 +73,49 @@ const Component: React.FC<ComponentProps> = ({
 }) => {
   const styles = useStyles()
 
+  const inputRef = useRef<TextInputInstance>(null)
+  const focusTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  )
+
+  /**
+   * Modal が前に出てから入力欄へフォーカスする
+   *
+   * @note
+   * Android の Modal は別ウィンドウのため、autoFocus では入力欄が
+   * 現れた時点でウィンドウにフォーカスが移っておらず、キーボードが
+   * 出ないことがある。表示され切ってから当てる。
+   */
+  const onShow = useCallback(() => {
+    let attempt = 0
+
+    const tryFocus = () => {
+      inputRef.current?.focus()
+      attempt += 1
+      if (attempt < FOCUS_MAX_ATTEMPTS) {
+        focusTimer.current = setTimeout(tryFocus, FOCUS_INTERVAL)
+      }
+    }
+
+    focusTimer.current = setTimeout(tryFocus, FOCUS_DELAY)
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (focusTimer.current) {
+        clearTimeout(focusTimer.current)
+      }
+    },
+    [],
+  )
+
   return (
     <Modal
       visible={isVisible}
       animationType="fade"
       transparent={true}
       onRequestClose={onCancel}
+      onShow={onShow}
     >
       {/*
         Android の Modal は別ウィンドウのため adjustResize が効かず、
@@ -78,12 +129,12 @@ const Component: React.FC<ComponentProps> = ({
             <Text style={styles.description}>{description}</Text>
           )}
           <TextInput
+            ref={inputRef}
             style={[styles.input, multiline && styles.multilineInput]}
             defaultValue={defaultValue}
             onChangeText={onChangeText}
             keyboardType={keyboardType ?? 'default'}
             autoCapitalize="none"
-            autoFocus={true}
             underlineColorAndroid="transparent"
             multiline={multiline}
             textAlignVertical={multiline ? 'top' : 'center'}
@@ -120,6 +171,13 @@ const Container: React.FC<Props> = (props) => {
       textRef.current = defaultValue ?? ''
     }
   }, [isVisible, defaultValue])
+
+  // 閉じたあとに余白が残らないようにする
+  useEffect(() => {
+    if (!isVisible) {
+      setKeyboardHeight(0)
+    }
+  }, [isVisible])
 
   useEffect(() => {
     const onShow = Keyboard.addListener('keyboardDidShow', (event) => {


### PR DESCRIPTION
> [!NOTE]
> [#489](https://github.com/mitsuharu/mobile-printer/pull/489)（Babel の修正）の上に積んでいます。#489 のマージ後にベースが `main` へ切り替わります。#489 が入っていないとテストが動かないためです。

## 症状

テキスト入力のダイアログで、**キーボードが出ないことがある**（毎回ではない）。

## 原因

`autoFocus` です。

`InputDialog` は `Modal` の中に `TextInput` を置いていますが、**Android の `Modal` は別ウィンドウ**です。入力欄がマウントされる時点でウィンドウにフォーカスが移っておらず、`autoFocus` が空振りすることがあります。タイミング依存なので「出る時と出ない時がある」という症状になります。

## 対応

`Modal` の `onShow`（表示され切ってから呼ばれる）で明示的に `focus()` を当てます。**1回では足りない場合があることを実測で確認した**ため、出なかったときに備えて数回当て直します。

あわせて、閉じたあとにキーボード分の余白が残らないようリセットしています。

## 実機での比較（SUNMI V2_PRO / Android 7.1.2）

`dumpsys input_method` の `mInputShown` で判定し、**各試行でアプリを再起動する**同一条件で比較しました。

| | キーボード表示 |
| --- | --- |
| 修正前（`autoFocus`） | 5 / 8 |
| 修正後（`onShow` + 再試行） | 16 / 16 |

依存更新の取り込み後に rebase してから、あらためて 8 / 8 で再確認しています。

### 測定の注意

途中、測定手順の不備で誤った結論を出しかけたので残しておきます。**キーボードが出ているとき、`KEYCODE_BACK` 1回ではキーボードが閉じるだけでダイアログが残ります。** そのため BACK で閉じながら連続測定すると結果が交互（表示・非表示）になり、修正の有無に関わらず約5割に見えます。各試行でアプリを再起動する方式に変えて解消しました。

## 検証

| コマンド | 結果 |
| --- | --- |
| `yarn typecheck` | 成功 |
| `yarn lint` | エラーなし |
| `TZ=Asia/Tokyo yarn test --runInBand` | 19 suites / 211 tests 成功 |
| `(cd android && ./gradlew assembleDebug)` | 成功 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
