### PR TITLE
ci: Babel のメジャー更新を止め、リリースバンドルをCIで検証する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,14 @@ updates:
           - 'babel'
           - '@babel/*'
           - 'babel-*'
+    # React Native 0.87 は Babel 8 に対応していない。
+    # @react-native/babel-preset が @babel/core ^7 を前提としており、8系にすると
+    # テストが動かず、リリースのJSバンドルも作れなくなる。
+    # React Native 側が対応するまで、メジャー更新は取り込まない。
+    ignore:
+      - dependency-name: '@babel/*'
+        update-types:
+          - 'version-update:semver-major'
   - package-ecosystem: 'github-actions'
     directory: '/'
     target-branch: 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,16 @@ jobs:
 
       - name: Build Debug APK
         run: cd android && ./gradlew assembleDebug
+
+      # デバッグビルドはJSをバンドルせず Metro から読むため、Babel の非互換など
+      # バンドル時にしか出ない破損を検出できない。リリース相当のバンドルを作って確かめる。
+      # Metro のキャッシュが残っていると失敗を見逃すため、毎回作り直す。
+      - name: Bundle JavaScript for release
+        run: |
+          yarn react-native bundle \
+            --platform android \
+            --dev false \
+            --reset-cache \
+            --entry-file index.js \
+            --bundle-output "${RUNNER_TEMP}/index.android.bundle" \
+            --assets-dest "${RUNNER_TEMP}/assets"


### PR DESCRIPTION
> [!NOTE]
> [#489](https://github.com/mitsuharu/mobile-printer/pull/489)（Babel を 7系へ戻す）の上に積んでいます。#489 のマージ後にベースが `main` へ切り替わります。

## 概要

[#489](https://github.com/mitsuharu/mobile-printer/pull/489) で直した破損が、**二度と同じ形で起きない／起きても気づけるように**します。

## 1. Dependabot で `@babel/*` のメジャー更新を止める

React Native 0.87 は Babel 8 に対応していません。放置すると Dependabot が再び8系へ上げてきます。

```yaml
ignore:
  - dependency-name: '@babel/*'
    update-types:
      - 'version-update:semver-major'
```

マイナー・パッチの更新はこれまでどおり届きます。React Native 側が Babel 8 に対応したら、この `ignore` を外して上げる形になります。

## 2. CIでリリース相当のJSバンドルを作る

**これまでCIでは今回の破損を検出できませんでした。** `ci.yml` は `assembleDebug` しか実行せず、**デバッグビルドはJSをバンドルしません**（Metro から読む）。バンドル時にしか出ない Babel の非互換は、リリースを打って初めて分かる状態でした。

`build_android` ジョブにリリース相当のバンドル作成を追加します。

### `--reset-cache` を付けている理由

**検証中に、Metro のキャッシュが失敗を隠す現象を実際に踏みました。** Babel 8 を入れた状態でも、直前の成功時のキャッシュが残っていると `exit=0` で通ってしまいます。キャッシュを捨てると同じ条件で `exit=1` になりました。CIは基本クリーンですが、キャッシュを持たせた場合でも確実に検査できるよう明示しています。

## 検証

CI手順と同じコマンドを、Babel 8 と Babel 7 の両方で実行して確かめました。

| 状態 | 結果 |
| --- | --- |
| Babel 8（`main` 相当）+ `--reset-cache` | **exit=1**（`The decorators plugin requires a 'version' option` で失敗）→ 検出できる |
| Babel 8 + キャッシュあり | exit=0（**見逃す**）→ `--reset-cache` を付けた理由 |
| Babel 7（#489 適用後） | exit=0、3,113,778 bytes 生成 |

あわせて `TZ=Asia/Tokyo yarn test --runInBand` は 19 suites / 211 tests 成功、`.github/dependabot.yml` と `.github/workflows/ci.yml` の YAML 構文も確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
