### PR TITLE
ci: Dependabot のPRでもCIを実行する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     directory: '/'
     target-branch: 'main'
     open-pull-requests-limit: 10
-    commit-message:
-      prefix: '[skip ci] '
     schedule:
       interval: 'weekly'
     groups:
@@ -43,5 +41,3 @@ updates:
     target-branch: 'main'
     schedule:
       interval: 'monthly'
-    commit-message:
-      prefix: '[skip ci] '


### PR DESCRIPTION
## 概要

`dependabot.yml` の `commit-message.prefix` から `[skip ci]` を外し、**依存更新のPRでもCIを実行する**ようにします。

```diff
-    commit-message:
-      prefix: '[skip ci] '
```

npm と GitHub Actions の両方から外しています。変更はこの4行の削除のみです。

## 経緯

当初は「PRのタイトルで実行を制御する」案を検討しましたが、取りやめました。**Dependabot にはPRタイトルだけへ接頭辞を付ける設定がなく**、タイトルはコミットメッセージから生成されるため、`commit-message.prefix` を指定すると必ず両方に入ります。GitHub の `[skip ci]` はコミットメッセージを見て実行自体を止めるので、ワークフロー側から覆せません。

そのため実現するにはマーカーを opt-in へ反転させる（タイトルに `[run ci]` を足したときだけ実行する）必要があり、毎回タイトルを編集する手間が増えます。**素直に毎回実行するほうが単純で確実**という判断です。

## 効果

**[#489](https://github.com/mitsuharu/mobile-printer/pull/489) の Babel 8 の破損は、これで取り込み前に気づけるようになります。** あの更新は、テストが全滅しリリースのJSバンドルも作れない状態のまま `main` へ入りました。CIが止まっていたことが一因です。

あわせて [#492](https://github.com/mitsuharu/mobile-printer/pull/492) でリリース相当のバンドル検証をCIへ追加済みなので、同種の破損は依存更新のPRの時点で落ちます。

## 引き換えになるもの

依存更新のPRごとに、テストと Android のデバッグビルド、リリースバンドルの作成が走ります。実行時間と使用量は増えます。

## 検証

`.github/dependabot.yml` の YAML 構文と構造を確認しました。既存の `groups` と `ignore`（`@babel/*` のメジャー更新抑止）はそのままです。

**この変更は既存のPRには効きません。** [#494](https://github.com/mitsuharu/mobile-printer/pull/494) などのコミットには `[skip ci]` が残っているため、CIを回すには Dependabot に作り直させる（PRで `@dependabot recreate` とコメント）か、空コミットを積む必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
