### PR TITLE
feat: 名刺レイアウトに罫線を入れ、区切り線で印刷が止まる不具合を直す

### DIFF
--- a/src/print/__test__/executePrintCommands.test.ts
+++ b/src/print/__test__/executePrintCommands.test.ts
@@ -26,6 +26,16 @@ const createPrinter = () => {
       calls.push(['readImage', path])
       return 'AAAA'
     },
+    buildHR: async (barType: string) => {
+      calls.push(['buildHR', barType])
+      return `<${barType}>`
+    },
+    enterBuffer: async () => {
+      calls.push(['enterBuffer'])
+    },
+    exitBuffer: async () => {
+      calls.push(['exitBuffer'])
+    },
   } as unknown as Printer
 
   return { printer, calls }
@@ -70,6 +80,8 @@ describe('executePrintCommands', () => {
     await executePrintCommands(commands, printer)
 
     expect(calls).toEqual([
+      ['buildHR', 'wave'],
+      ['enterBuffer'],
       ['setAlignment', 'center'],
       ['setFontSize', 32],
       ['setTextStyle', 'bold', true],
@@ -83,8 +95,9 @@ describe('executePrintCommands', () => {
         [10, 22],
         ['left', 'left'],
       ],
-      ['printHR', 'wave'],
+      ['printHR', '<wave>'],
       ['lineWrap', 3],
+      ['exitBuffer'],
     ])
   })
 
@@ -100,13 +113,15 @@ describe('executePrintCommands', () => {
     )
 
     expect(calls.map(([name]) => name)).toEqual([
+      'enterBuffer',
       'printText',
       'setFontSize',
       'printText',
+      'exitBuffer',
     ])
   })
 
-  it('途中で失敗したらそこで止める', async () => {
+  it('途中で失敗したらそこで止め、バッファから出る', async () => {
     const { printer, calls } = createPrinter()
     const failing: Printer = {
       ...printer,
@@ -126,6 +141,55 @@ describe('executePrintCommands', () => {
       ),
     ).rejects.toThrow('printer error')
 
-    expect(calls.map(([name]) => name)).toEqual(['setFontSize'])
+    // バッファから出ないままだと、次の印刷が溜まったまま出てこない
+    expect(calls.map(([name]) => name)).toEqual([
+      'enterBuffer',
+      'setFontSize',
+      'exitBuffer',
+    ])
+  })
+})
+
+describe('executePrintCommands の区切り線', () => {
+  it('区切り線の文字列は、バッファへ入る前に作る', async () => {
+    // 用紙幅の問い合わせはバッファ中に応答が返らず、印刷ごと止まってしまう
+    const { printer, calls } = createPrinter()
+    const commands: PrintCommand[] = [
+      { type: 'printText', text: '所属の前' },
+      { type: 'printHR', barType: 'line' },
+      { type: 'printText', text: '株式会社 織田軍' },
+      { type: 'printHR', barType: 'line' },
+      { type: 'lineWrap', count: 3 },
+    ]
+
+    await executePrintCommands(commands, printer)
+
+    expect(calls).toEqual([
+      ['buildHR', 'line'],
+      ['enterBuffer'],
+      ['printText', '所属の前'],
+      ['printHR', '<line>'],
+      ['printText', '株式会社 織田軍'],
+      ['printHR', '<line>'],
+      ['lineWrap', 3],
+      ['exitBuffer'],
+    ])
+  })
+
+  it('同じ種類の区切り線は一度だけ作る', async () => {
+    const { printer, calls } = createPrinter()
+    await executePrintCommands(
+      [
+        { type: 'printHR', barType: 'line' },
+        { type: 'printHR', barType: 'wave' },
+        { type: 'printHR', barType: 'line' },
+      ],
+      printer,
+    )
+
+    expect(calls.filter(([name]) => name === 'buildHR')).toEqual([
+      ['buildHR', 'line'],
+      ['buildHR', 'wave'],
+    ])
   })
 })

--- a/src/print/__test__/presets.test.ts
+++ b/src/print/__test__/presets.test.ts
@@ -159,11 +159,44 @@ describe('createPresets の印刷内容', () => {
     ])
   })
 
-  it('区切り線は入れない', () => {
-    // 区切り線は利用者がレイアウトで足すもので、初期状態では出さない
+  it('所属の上とSNSの上下に罫線を入れる', () => {
+    const commands = commandsFor('サンプル')
+    const marks = commands.flatMap((command) => {
+      if (command.type === 'printHR') {
+        return ['---']
+      }
+      if (command.type === 'printText') {
+        return [command.text]
+      }
+      if (command.type === 'printColumns') {
+        return [command.texts.join(' ')]
+      }
+      return []
+    })
+
+    expect(marks).toEqual([
+      '織田信長',
+      'Nobunaga Oda',
+      '人間五十年、下天の内をくらぶれば、夢幻の如くなり',
+      '---',
+      '株式会社 織田軍',
+      '代表取締役大名',
+      '尾張国',
+      '---',
+      'X: tw',
+      'Facebook: fb',
+      'GitHub: gh',
+      'Website: https://example.com/',
+      '---',
+      'go to Wikipedia',
+      '1970/01/01 09:00',
+    ])
+  })
+
+  it('罫線は3本だけにする', () => {
     expect(
-      commandsFor('サンプル').some((command) => command.type === 'printHR'),
-    ).toBe(false)
+      commandsFor('サンプル').filter((command) => command.type === 'printHR'),
+    ).toHaveLength(3)
   })
 
   it('アイコン画像とQRコードを出力する', () => {

--- a/src/print/__test__/presets.test.ts
+++ b/src/print/__test__/presets.test.ts
@@ -153,10 +153,9 @@ describe('createPresets の印刷内容', () => {
       command.type === 'lineWrap' ? [{ index, count: command.count }] : [],
     )
 
-    // 冒頭・画像の前後・各まとまりの前・QRコードの前後・末尾の紙送り
-    expect(blanks.map(({ count }) => count)).toEqual([
-      1, 1, 2, 1, 1, 1, 1, 2, 3,
-    ])
+    // 冒頭・画像の前後・所属の前・QRコードの前後・末尾の紙送り
+    // 罫線の前後には空けない。罫線そのものが区切りになる。
+    expect(blanks.map(({ count }) => count)).toEqual([1, 1, 2, 1, 1, 2, 3])
   })
 
   it('所属の上とSNSの上下に罫線を入れる', () => {

--- a/src/print/executePrintCommands.ts
+++ b/src/print/executePrintCommands.ts
@@ -35,8 +35,30 @@ export type Printer = {
     widths: number[],
     alignments: SunmiPrinterLibrary.Alignment[],
   ) => void
-  printHR: (barType: SunmiPrinterLibrary.BarType) => void
+  /**
+   * 区切り線の文字列を作る
+   *
+   * @note
+   * 用紙幅をプリンターへ問い合わせる。バッファへ入ったあとは応答が返らず
+   * 固まるため、入る前に呼ぶこと。
+   */
+  buildHR: (barType: SunmiPrinterLibrary.BarType) => Promise<string>
+
+  /**
+   * 区切り線を印字する
+   *
+   * @note
+   * 用紙幅いっぱいの記号なので、直前の要素が文字を大きくしていても
+   * 既定の大きさで印字する。
+   */
+  printHR: (text: string) => void
   lineWrap: (count: number) => void
+
+  /**
+   * 1件の印刷をまとめて送るための、プリンターのバッファ
+   */
+  enterBuffer: () => Promise<void>
+  exitBuffer: () => Promise<void>
 }
 
 /**
@@ -55,18 +77,67 @@ export const defaultPrinter: Printer = {
     SunmiPrinterLibrary.printQRCode(text, moduleSize, errorLevel),
   printColumnsString: (texts, widths, alignments) =>
     SunmiPrinterLibrary.printColumnsString(texts, widths, alignments),
-  printHR: (barType) => SunmiPrinterLibrary.printHR(barType),
+  buildHR: (barType) => SunmiPrinterLibrary.hr(barType),
+  printHR: (text) =>
+    SunmiPrinterLibrary.printTextWithFont(
+      text,
+      'default',
+      SunmiPrinterLibrary.defaultFontSize,
+    ),
   lineWrap: (count) => SunmiPrinterLibrary.lineWrap(count),
+  enterBuffer: () => SunmiPrinterLibrary.enterPrinterBuffer(true),
+  exitBuffer: () => SunmiPrinterLibrary.exitPrinterBuffer(true),
+}
+
+/**
+ * 区切り線の文字列を、種類ごとに作っておく
+ *
+ * @note
+ * 用紙幅の問い合わせはプリンターのバッファ中に応答が返らない。送り始める
+ * 前にまとめて作る。
+ */
+const buildHRTexts = async (
+  commands: PrintCommand[],
+  printer: Printer,
+): Promise<Map<SunmiPrinterLibrary.BarType, string>> => {
+  const texts = new Map<SunmiPrinterLibrary.BarType, string>()
+  for (const command of commands) {
+    if (command.type === 'printHR' && !texts.has(command.barType)) {
+      texts.set(command.barType, await printer.buildHR(command.barType))
+    }
+  }
+  return texts
 }
 
 /**
  * 組み立てた操作をプリンターへ送る
  *
  * 画像はパスで受け取り、送る直前にファイルから読む。
+ * 割り込みを防ぐため、1件の印刷はバッファへまとめて送る。
  */
 export const executePrintCommands = async (
   commands: PrintCommand[],
   printer: Printer = defaultPrinter,
+): Promise<void> => {
+  // 送るものがなければ、バッファの開け閉めもしない
+  if (commands.length === 0) {
+    return
+  }
+
+  const hrTexts = await buildHRTexts(commands, printer)
+
+  await printer.enterBuffer()
+  try {
+    await send(commands, printer, hrTexts)
+  } finally {
+    await printer.exitBuffer()
+  }
+}
+
+const send = async (
+  commands: PrintCommand[],
+  printer: Printer,
+  hrTexts: Map<SunmiPrinterLibrary.BarType, string>,
 ): Promise<void> => {
   for (const command of commands) {
     switch (command.type) {
@@ -101,9 +172,13 @@ export const executePrintCommands = async (
           command.alignments,
         )
         break
-      case 'printHR':
-        printer.printHR(command.barType)
+      case 'printHR': {
+        const text = hrTexts.get(command.barType)
+        if (text) {
+          printer.printHR(text)
+        }
         break
+      }
       case 'lineWrap':
         printer.lineWrap(command.count)
         break

--- a/src/print/presets/index.ts
+++ b/src/print/presets/index.ts
@@ -81,6 +81,12 @@ const spacer = (lines: number): LayoutElement => ({
   lines,
 })
 
+const divider = (): LayoutElement => ({
+  id: createUUID(),
+  type: 'divider',
+  barType: 'line',
+})
+
 /**
  * 名刺レイアウトと、その入力項目のIDを作る
  *
@@ -119,18 +125,21 @@ const createProfileLayout = (): {
     spacer(2),
     centeredText(fieldIds.description, FONT_SIZE.DEFAULT),
 
-    // 区切り線は利用者がレイアウトで足すものとし、ここでは行を空けるだけにする
+    // 所属の上と、SNSの上下を罫線で区切る
     spacer(1),
+    divider(),
     centeredText(fieldIds.company, FONT_SIZE.DEFAULT),
     centeredText(fieldIds.position, FONT_SIZE.DEFAULT),
     centeredText(fieldIds.address, FONT_SIZE.DEFAULT),
 
     spacer(1),
+    divider(),
     snsColumns('X:', fieldIds.twitter),
     snsColumns('Facebook:', fieldIds.facebook),
     snsColumns('GitHub:', fieldIds.github),
     snsColumns('Website:', fieldIds.website),
 
+    divider(),
     spacer(1),
     centeredText(fieldIds.qrDescription, FONT_SIZE.DEFAULT),
     spacer(1),

--- a/src/print/presets/index.ts
+++ b/src/print/presets/index.ts
@@ -132,7 +132,6 @@ const createProfileLayout = (): {
     centeredText(fieldIds.position, FONT_SIZE.DEFAULT),
     centeredText(fieldIds.address, FONT_SIZE.DEFAULT),
 
-    spacer(1),
     divider(),
     snsColumns('X:', fieldIds.twitter),
     snsColumns('Facebook:', fieldIds.facebook),
@@ -140,7 +139,6 @@ const createProfileLayout = (): {
     snsColumns('Website:', fieldIds.website),
 
     divider(),
-    spacer(1),
     centeredText(fieldIds.qrDescription, FONT_SIZE.DEFAULT),
     spacer(1),
     {

--- a/src/redux/modules/printData/saga/printLayout.ts
+++ b/src/redux/modules/printData/saga/printLayout.ts
@@ -1,4 +1,3 @@
-import * as SunmiPrinterLibrary from '@mitsuharu/react-native-sunmi-printer-library'
 import { call, put, select } from 'redux-saga/effects'
 import type { Layout, PrintCommand, PrintData } from '@/print'
 import { buildPrintCommands, executePrintCommands } from '@/print'
@@ -49,22 +48,9 @@ export function* printLayoutSaga({ payload }: ReturnType<typeof printLayout>) {
       return
     }
 
-    yield call(print, commands)
+    yield call(executePrintCommands, commands)
   } catch (e: any) {
     console.warn('printLayoutSaga', e)
     yield put(enqueueSnackbar({ message: `印刷に失敗しました` }))
-  }
-}
-
-async function print(commands: PrintCommand[]) {
-  try {
-    // 割り込みを防ぐため、1件の印刷をまとめて送る
-    await SunmiPrinterLibrary.enterPrinterBuffer(true)
-    await executePrintCommands(commands)
-  } catch (e: any) {
-    console.warn('print', e)
-    throw e
-  } finally {
-    await SunmiPrinterLibrary.exitPrinterBuffer(true)
   }
 }


### PR DESCRIPTION
## 概要

初期状態の名刺レイアウトに罫線を3本入れます。従来のプロフィール印刷は、所属の上とSNSの上下を罫線で区切っていました。

あわせて、罫線を入れたことで見つかった印刷の不具合を直します。

## 罫線の位置

要素として3本並べるだけで、印刷側の解釈は変えていません。利用者が組んだレイアウトに勝手な罫線が入らない点は今までどおりです。

- フリーテキストと所属の間
- 所属とSNSの間
- SNSとQRコードの説明の間

罫線そのものが区切りになるため、罫線の前後には空行を入れていません。

| 変更前 | 変更後 |
| --- | --- |
| <img width="300" alt="変更前: 罫線がない" src="https://github.com/user-attachments/assets/c1762ec5-0747-4633-bfe8-6d51a7226a1a" /> | <img width="300" alt="変更後: 所属の上とSNSの上下に罫線が入る" src="https://github.com/user-attachments/assets/2b48c1ee-ce01-40e6-9591-32c9c525147b" /> |

## 区切り線を入れると印刷が止まる不具合

ライブラリの `printHR` は、線を組み立てるために用紙幅をプリンターへ問い合わせてから印字します。この問い合わせは `enterPrinterBuffer` でバッファに入っている間は応答が返らず、待つと印刷そのものが止まっていました。

実機のログでも `printHR` の手前で進まなくなっていました。

```
PRINTDBG enter
PRINTDBG entered
PRINTDBG hr start     ← ここから先へ進まない
```

待たずに送っていた元の実装では、宙に浮いた問い合わせがバッファを出したあとに解決するため、罫線だけが末尾へ回って印字されていました。どちらも同じ原因です。初期レイアウトに罫線がなかったため、これまで表に出ていませんでした。

罫線の文字列はバッファへ入る前にまとめて作り、送るときは印字だけをするようにしました。順序の制約を1か所へ集めるため、バッファの開け閉めも `executePrintCommands` が持ちます。

```ts
const hrTexts = await buildHRTexts(commands, printer)

await printer.enterBuffer()
try {
  await send(commands, printer, hrTexts)
} finally {
  await printer.exitBuffer()
}
```

## 適用範囲

プリセットは初回起動時（`databaseSaga` が `isCreated` のときだけ `seedPresets` を呼ぶ）にだけ書き込みます。すでに使っている端末の名刺レイアウトは変わりません。罫線が要るときは、要素の編集から追加していただく形になります。

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
```

- typecheck・lint（警告76件はすべて既存分）・テスト220件が通過
- 追加したテスト
  - 名刺レイアウトが所属の上とSNSの上下に罫線を出すこと、罫線は3本だけであること
  - 罫線の文字列をバッファへ入る前に作ること、同じ種類は一度だけ作ること、途中で失敗してもバッファから出ること
- SUNMI V2 PRO（Android 7.1.2）でアプリのデータを消してからサンプルを印刷し、罫線3本の位置と余白を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
