### PR TITLE
fix: ステータスバーの文字が背景と同化して読めないのを直す

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { NavigationContainer } from '@react-navigation/native'
 import type React from 'react'
+import { StatusBar } from 'react-native'
 import { GlobalSnackbar } from '@/components/GlobalSnackbar'
 import * as NavigationService from '@/utils/NavigationService'
 import type { MainParams } from './main.params'
@@ -10,9 +11,10 @@ import { useAppTheme } from './theme/useAppTheme'
  * @see https://reactnavigation.org/docs/auth-flow/
  */
 const Routes: React.FC = () => {
-  const { navigationTheme } = useAppTheme()
+  const { navigationTheme, statusBarStyle } = useAppTheme()
   return (
     <>
+      <StatusBar barStyle={statusBarStyle} />
       <NavigationContainer
         theme={navigationTheme}
         ref={NavigationService.navigationRef}

--- a/src/routes/theme/__test__/statusBarStyle.test.ts
+++ b/src/routes/theme/__test__/statusBarStyle.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals'
+import { makeStatusBarStyle } from '../statusBarStyle'
+
+describe('makeStatusBarStyle', () => {
+  it('明るい配色では濃い色で描く', () => {
+    expect(makeStatusBarStyle('light')).toBe('dark-content')
+  })
+
+  it('暗い配色では白で描く', () => {
+    expect(makeStatusBarStyle('dark')).toBe('light-content')
+  })
+
+  it('配色が分からないときは明るい配色として扱う', () => {
+    // 端末の設定を読めないときも、既定の見た目は明るい配色になる
+    expect(makeStatusBarStyle(null)).toBe('dark-content')
+  })
+})

--- a/src/routes/theme/statusBarStyle.ts
+++ b/src/routes/theme/statusBarStyle.ts
@@ -1,0 +1,13 @@
+import type { ColorSchemeName, StatusBarStyle } from 'react-native'
+
+/**
+ * ステータスバーの文字と絵柄の色を決める
+ *
+ * @note
+ * 端末の画面いっぱいに描く設定（`edgeToEdgeEnabled`）のため、ステータスバーの
+ * 裏にはアプリの背景がそのまま出る。背景に合う色を指定しないと、明るい背景に
+ * 白い時計が重なって読めなくなる。
+ */
+export const makeStatusBarStyle = (
+  colorScheme: ColorSchemeName | null,
+): StatusBarStyle => (colorScheme === 'dark' ? 'light-content' : 'dark-content')

--- a/src/routes/theme/useAppTheme.ts
+++ b/src/routes/theme/useAppTheme.ts
@@ -2,6 +2,7 @@ import type { Theme as NavigationTheme } from '@react-navigation/native'
 import { useEffect, useState } from 'react'
 import { useColorScheme } from 'react-native'
 import { makeTheme as makeNavigationTheme } from './navigationTheme'
+import { makeStatusBarStyle } from './statusBarStyle'
 
 export const useAppTheme = () => {
   const colorScheme = useColorScheme()
@@ -13,5 +14,5 @@ export const useAppTheme = () => {
     setNavigationTheme(makeNavigationTheme(colorScheme))
   }, [colorScheme])
 
-  return { navigationTheme }
+  return { navigationTheme, statusBarStyle: makeStatusBarStyle(colorScheme) }
 }


### PR DESCRIPTION
## 概要

ステータスバーの時計やアイコンが白のままで、明るい背景に重なって読めませんでした。配色に合わせて色を変えます。

| 変更前 | 変更後 |
| --- | --- |
| <img width="300" alt="変更前: 白い時計が明るい背景に重なって読めない" src="https://github.com/user-attachments/assets/8d518f37-ea13-4f56-a8c0-63e365a42cab" /> | <img width="300" alt="変更後: 濃い色になって読める" src="https://github.com/user-attachments/assets/6dfd94c0-74ba-49a0-9d35-a41c220d8760" /> |

## 原因

`android/gradle.properties` の `edgeToEdgeEnabled=true` により、アプリは画面いっぱいに描いています。ステータスバーの裏にはアプリの背景がそのまま出るため、白い文字が明るい背景に重なっていました。

これまで色を指定していなかったので、端末の既定（白）のままでした。

## 直し方

配色に合わせて `StatusBar` の `barStyle` を切り替えます。明るいときは濃い色、暗いときは白です。

```ts
export const makeStatusBarStyle = (
  colorScheme: ColorSchemeName | null,
): StatusBarStyle => (colorScheme === 'dark' ? 'light-content' : 'dark-content')
```

`backgroundColor` は指定していません。画面いっぱいに描く設定では効かず、React Native でも非推奨になっているためです。

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
```

- typecheck・lint（警告77件はすべて既存分）・テスト220件が通過
- 配色ごとの色の決まり方にテストを追加
- SUNMI V2 PRO（Android 7.1.2）で、時計と各アイコンが読めることを確認
- 暗い配色はこの端末（Android 7.1.2）にOSの設定がないため、実機で確認できていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
