### PR TITLE
chore(release): バージョンを1.0.0にする

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,8 +82,8 @@ android {
         applicationId "com.mobpri"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.0.0"
     }
     signingConfigs {
         debug {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobpri",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## 概要

バージョンを 1.0.0 にします。動作確認後、メンテナーがタグを打ってリリースします。

| | 変更前 | 変更後 |
| --- | --- | --- |
| `versionName` | 1.0 | 1.0.0 |
| `versionCode` | 1 | 2 |
| `package.json` の `version` | 0.0.1 | 1.0.0 |

`versionCode` は init 以降ずっと 1 のままで、これまで配布したビルドもすべて 1 です。Android は `versionCode` が大きいものだけを更新として扱うため、据え置くと DeployGate からの更新が既存のインストールへ届きません。あわせて 2 へ上げています。

`package.json` は `private: true` でアプリの表示には使われませんが、リリースの版として揃えました。`yarn.lock` に差分は出ていません。

| 変更前 | 変更後 |
| --- | --- |
| <img width="300" alt="変更前: 1.0 (1)" src="https://github.com/user-attachments/assets/acf08756-045f-4cba-9c03-388e687dfd85" /> | <img width="300" alt="変更後: 1.0.0 (2)" src="https://github.com/user-attachments/assets/3d259ddb-02a9-4003-b6ed-a3741ac1dabd" /> |

## リリース手順（メンテナー向け）

このPRをマージしたあと、タグを push すると `.github/workflows/publish.yml` が GitHub Releases と DeployGate へ配布します。

```sh
git tag 1.0.0
git push origin 1.0.0
```

タグ名に `-` を含めるとプレリリース扱いになります。`1.0.0` は含まないため通常のリリースです。`workflow_dispatch` から実行することもできます。

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
(cd android && ./gradlew installRelease)
```

- typecheck・lint（警告76件はすべて既存分）・テスト223件が通過
- SUNMI V2 PRO（Android 7.1.2）へリリースビルドをインストールし、`dumpsys package` が `versionName=1.0.0` / `versionCode=2` を返すこと、アプリ情報の画面に `1.0.0 (2)` と出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
