### PR TITLE
feat(print-data): 印刷データの削除を届く場所に置く

### DIFF
--- a/src/screens/Home/PrintDataCell.tsx
+++ b/src/screens/Home/PrintDataCell.tsx
@@ -21,6 +21,7 @@ type Props = {
   layoutName?: string
   onPressPrint: (printData: PrintData) => void
   onPressEdit: (printData: PrintData) => void
+  onLongPress: (printData: PrintData) => void
 }
 
 /**
@@ -28,18 +29,24 @@ type Props = {
  *
  * 本体をタップすると印刷し、右のボタンから内容の編集へ進む。
  * 編集を階層の奥に置くと、印刷内容を直すたびに何度もたどることになる。
+ * 長押しすると複製と削除ができる。レイアウトの一覧と同じ操作にしている。
  */
 export const PrintDataCell: React.FC<Props> = ({
   printData,
   layoutName,
   onPressPrint,
   onPressEdit,
+  onLongPress,
 }) => {
   const styles = useStyles()
 
   return (
     <View style={styles.container}>
-      <Button style={styles.content} onPress={() => onPressPrint(printData)}>
+      <Button
+        style={styles.content}
+        onPress={() => onPressPrint(printData)}
+        onLongPress={() => onLongPress(printData)}
+      >
         <Text style={styles.title}>{printData.title}</Text>
         {!!layoutName && <Text style={styles.subtitle}>{layoutName}</Text>}
       </Button>

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -2,8 +2,10 @@ import { useNavigation } from '@react-navigation/native'
 import type React from 'react'
 import { useCallback, useLayoutEffect, useMemo } from 'react'
 import { StyleSheet, type ViewStyle } from 'react-native'
+import AlertAsync from 'react-native-alert-async'
 import { makeStyles } from 'react-native-swag-styles'
 import { useDispatch, useSelector } from 'react-redux'
+import { MESSAGE } from '@/CONSTANTS'
 import { Cell, Section } from '@/components/List'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
 import { SafeScrollView } from '@/components/SafeScrollView'
@@ -13,7 +15,11 @@ import {
   selectLayouts,
 } from '@/redux/modules/layout/selectors'
 import { selectAllPrintData } from '@/redux/modules/printData/selectors'
-import { printLayout } from '@/redux/modules/printData/slice'
+import {
+  deletePrintData,
+  duplicatePrintData,
+  printLayout,
+} from '@/redux/modules/printData/slice'
 import { printText } from '@/redux/modules/printer/slice'
 import { styleType } from '@/utils/styles'
 import { AppInfoButton } from './AppInfoButton'
@@ -28,6 +34,7 @@ type ComponentProps = Props & {
   onPressText: (text: string) => void
   onPressPrintData: (value: PrintData) => void
   onPressEditPrintData: (value: PrintData) => void
+  onLongPressPrintData: (value: PrintData) => void
   onNavigateToPrinter: () => void
   onNavigateToLayoutList: () => void
 }
@@ -39,6 +46,7 @@ const Component: React.FC<ComponentProps> = ({
   onPressText,
   onPressPrintData,
   onPressEditPrintData,
+  onLongPressPrintData,
   onNavigateToPrinter,
   onNavigateToLayoutList,
 }) => {
@@ -75,6 +83,7 @@ const Component: React.FC<ComponentProps> = ({
                 layoutName={layoutNames[value.layoutId]}
                 onPressPrint={onPressPrintData}
                 onPressEdit={onPressEditPrintData}
+                onLongPress={onLongPressPrintData}
               />
             ))
           )}
@@ -141,6 +150,39 @@ const Container: React.FC<Props> = (props) => {
     [navigation],
   )
 
+  const onLongPressPrintData = useCallback(
+    async (value: PrintData) => {
+      try {
+        const action = await AlertAsync(value.title, '操作を選んでください', [
+          { text: '複製する', onPress: () => 'duplicate' },
+          { text: '削除する', onPress: () => 'delete', style: 'destructive' },
+        ])
+
+        if (action === 'duplicate') {
+          dispatch(duplicatePrintData(value))
+          return
+        }
+
+        if (action === 'delete') {
+          const confirmed = await AlertAsync(
+            '確認',
+            `「${value.title}」を削除しますか？`,
+            [
+              { text: MESSAGE.NO, onPress: () => false, style: 'cancel' },
+              { text: MESSAGE.YES, onPress: () => true },
+            ],
+          )
+          if (confirmed) {
+            dispatch(deletePrintData(value))
+          }
+        }
+      } catch (e: any) {
+        console.warn('onLongPressPrintData', e)
+      }
+    },
+    [dispatch],
+  )
+
   const onNavigateToPrinter = useCallback(() => {
     navigation.navigate('Printer')
   }, [navigation])
@@ -159,6 +201,7 @@ const Container: React.FC<Props> = (props) => {
         onPressText,
         onPressPrintData,
         onPressEditPrintData,
+        onLongPressPrintData,
         onNavigateToPrinter,
         onNavigateToLayoutList,
       }}

--- a/src/screens/PrintDataForm/index.tsx
+++ b/src/screens/PrintDataForm/index.tsx
@@ -13,16 +13,21 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import AlertAsync from 'react-native-alert-async'
 import { makeStyles } from 'react-native-swag-styles'
 import { useDispatch, useSelector } from 'react-redux'
-import { BASE64, COLOR } from '@/CONSTANTS'
+import { BASE64, COLOR, MESSAGE } from '@/CONSTANTS'
 import { ImageFileView } from '@/components/ImageFileView'
 import { Cell, Section } from '@/components/List'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, LayoutField, PrintData, PrintDataValue } from '@/print'
 import { selectLayoutById } from '@/redux/modules/layout/selectors'
 import { selectPrintDataById } from '@/redux/modules/printData/selectors'
-import { printLayout, savePrintData } from '@/redux/modules/printData/slice'
+import {
+  deletePrintData,
+  printLayout,
+  savePrintData,
+} from '@/redux/modules/printData/slice'
 import type { MainParams } from '@/routes/main.params'
 import { copyImageFile } from '@/utils/imageStore'
 import { styleType } from '@/utils/styles'
@@ -41,6 +46,7 @@ type ComponentProps = Props & {
   onPressPreview: () => void
   onPressPrint: () => void
   onPressLayout: () => void
+  onPressDelete: () => void
 }
 
 const textValueOf = (value: PrintDataValue | undefined) =>
@@ -58,6 +64,7 @@ const Component: React.FC<ComponentProps> = ({
   onPressPreview,
   onPressPrint,
   onPressLayout,
+  onPressDelete,
 }) => {
   const styles = useStyles()
 
@@ -133,6 +140,7 @@ const Component: React.FC<ComponentProps> = ({
           onPress={onPressLayout}
           accessory="disclosure"
         />
+        <Cell title="この印刷データを削除する" onPress={onPressDelete} />
       </Section>
     </SafeScrollView>
   )
@@ -217,6 +225,28 @@ const Container: React.FC<Props> = (props) => {
     navigation.navigate('LayoutEditor', { layoutId })
   }, [layoutId, navigation])
 
+  const onPressDelete = useCallback(async () => {
+    if (!printData) {
+      return
+    }
+    try {
+      const confirmed = await AlertAsync(
+        '確認',
+        `「${printData.title}」を削除しますか？`,
+        [
+          { text: MESSAGE.NO, onPress: () => false, style: 'cancel' },
+          { text: MESSAGE.YES, onPress: () => true },
+        ],
+      )
+      if (confirmed) {
+        dispatch(deletePrintData(printData))
+        navigation.goBack()
+      }
+    } catch (e: any) {
+      console.warn('onPressDelete', e)
+    }
+  }, [dispatch, navigation, printData])
+
   return (
     <Component
       {...props}
@@ -229,6 +259,7 @@ const Container: React.FC<Props> = (props) => {
         onPressPreview,
         onPressPrint,
         onPressLayout,
+        onPressDelete,
       }}
     />
   )


### PR DESCRIPTION
## 概要

印刷データの削除が、たどり着けない場所にしかありませんでした。編集画面とホームの長押しから届くようにします。

## なぜ届かなかったか

削除は以前から印刷データの一覧（レイアウトを管理する → レイアウト → 印刷データ）のセル長押しにありました。ところがホームの鉛筆から編集画面へ直接進めるようにしたため、**一覧を通らずに済むようになり、削除に触れる機会がなくなっていました。**

レイアウトは一覧が唯一の入口なので気付けますが、印刷データは一覧を飛ばせてしまう、という非対称です。

## 直し方

**編集画面の「操作」に「この印刷データを削除する」を足しました。** 要素の編集画面にすでに「この要素を削除する」があるので、作りを揃えています。確認を挟んでから削除し、一覧へ戻ります。

| 編集画面 | 確認 |
| --- | --- |
| <img width="300" alt="編集画面の操作" src="https://github.com/user-attachments/assets/1cc48e85-8a81-46ec-b60b-826ae76f31ad" /> | <img width="300" alt="削除の確認" src="https://github.com/user-attachments/assets/abe05f13-2aa7-4186-b454-2d5713a53753" /> |

**ホームの印刷データも長押しできるようにしました。** 「複製する / 削除する」を出します。印刷はタップ、編集は鉛筆で届くため、長押しには残りの2つだけを置いています。操作の組み立てはレイアウトの一覧と同じです。

| 長押し |
| --- |
| <img width="300" alt="ホームの長押し" src="https://github.com/user-attachments/assets/257e9355-5957-4db0-a80a-a8edb2dd0f0e" /> |

一覧側の長押し（印刷する / 複製する / 削除する）はそのまま残しています。

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
```

- typecheck・lint（警告79件はすべて既存分、エラーなし）・テスト223件が通過
- SUNMI V2 PRO（Android 7.1.2）で、ホームの長押しから複製 → 編集画面から削除、までを通しで確認
- 既存の印刷データは触らずに、複製したものを削除して確かめています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
