### PR TITLE
feat(routes): 処理されなかった遷移を利用者に知らせる

### DIFF
--- a/src/routes/__test__/unhandledAction.test.ts
+++ b/src/routes/__test__/unhandledAction.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@jest/globals'
+import type { NavigationAction } from '@react-navigation/native'
+import { describeUnhandledAction } from '../unhandledAction'
+
+const action = (value: unknown) => value as NavigationAction
+
+describe('describeUnhandledAction', () => {
+  it('遷移先の画面名を添える', () => {
+    expect(
+      describeUnhandledAction(
+        action({ type: 'NAVIGATE', payload: { name: 'LayoutList' } }),
+      ),
+    ).toBe('画面を開けませんでした（LayoutList）')
+  })
+
+  it('画面名がなければ操作の種類を添える', () => {
+    // 戻る操作には遷移先の名前がない
+    expect(describeUnhandledAction(action({ type: 'GO_BACK' }))).toBe(
+      '画面を移動できませんでした（GO_BACK）',
+    )
+  })
+
+  it('画面名が空文字なら操作の種類を添える', () => {
+    expect(
+      describeUnhandledAction(
+        action({ type: 'NAVIGATE', payload: { name: '' } }),
+      ),
+    ).toBe('画面を移動できませんでした（NAVIGATE）')
+  })
+})

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,23 +1,48 @@
-import { NavigationContainer } from '@react-navigation/native'
+import {
+  type NavigationAction,
+  NavigationContainer,
+} from '@react-navigation/native'
 import type React from 'react'
+import { useCallback } from 'react'
 import { StatusBar } from 'react-native'
+import { useDispatch } from 'react-redux'
 import { GlobalSnackbar } from '@/components/GlobalSnackbar'
+import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
 import * as NavigationService from '@/utils/NavigationService'
 import type { MainParams } from './main.params'
 import { RootRoutes } from './root.routes'
 import { useAppTheme } from './theme/useAppTheme'
+import { describeUnhandledAction } from './unhandledAction'
 
 /**
  * @see https://reactnavigation.org/docs/auth-flow/
  */
 const Routes: React.FC = () => {
+  const dispatch = useDispatch()
   const { navigationTheme, statusBarStyle } = useAppTheme()
+
+  /**
+   * 遷移が処理されなかったことを利用者に知らせる
+   *
+   * @note
+   * 既定では開発ビルドでしか警告が出ず、リリースビルドでは何も起きずに
+   * 終わる。押したのに動かない状態を黙って通さないようにする。
+   */
+  const onUnhandledAction = useCallback(
+    (action: NavigationAction) => {
+      console.warn('onUnhandledAction', action)
+      dispatch(enqueueSnackbar({ message: describeUnhandledAction(action) }))
+    },
+    [dispatch],
+  )
+
   return (
     <>
       <StatusBar barStyle={statusBarStyle} />
       <NavigationContainer
         theme={navigationTheme}
         ref={NavigationService.navigationRef}
+        onUnhandledAction={onUnhandledAction}
       >
         <RootRoutes />
       </NavigationContainer>

--- a/src/routes/unhandledAction.ts
+++ b/src/routes/unhandledAction.ts
@@ -1,0 +1,17 @@
+import type { NavigationAction } from '@react-navigation/native'
+
+/**
+ * 遷移が処理されなかったときに出す文言を作る
+ *
+ * @note
+ * React Native の既定の警告は開発ビルドでしか出ない。リリースビルドでは
+ * 何も起きずに終わってしまい、利用者にも開発者にも手がかりが残らない。
+ * 画面名まで添えて、どの遷移が捨てられたのかを分かるようにする。
+ */
+export const describeUnhandledAction = (action: NavigationAction): string => {
+  const name = (action.payload as { name?: unknown } | undefined)?.name
+  if (typeof name === 'string' && name !== '') {
+    return `画面を開けませんでした（${name}）`
+  }
+  return `画面を移動できませんでした（${action.type}）`
+}


### PR DESCRIPTION
## 概要

「トップ画面でタップしても、印刷も画面遷移もしない」という報告があり、再現を追っています。**そのときに手がかりが残るようにします。**

## いまの状況

- タップするとセルはハイライトするので、タッチもJSの再描画も生きています
- 印刷（Reduxのdispatch）は動きます
- 「レイアウトを管理する」「その他」「このアプリについて」の**すべての遷移が効きません**

つまり `navigation.navigate(...)` が呼ばれても処理されていない、という筋です。ところが React Navigation の既定の警告（`The action 'NAVIGATE' ... was not handled by any navigator`）は**開発ビルドでしか出ません。** リリースビルドでは何も起きずに終わり、利用者にも開発者にも手がかりが残りません。

自動操作で15サイクル試しましたが再現しなかったため、まず**次に起きたときに確実に分かる状態**を作ります。

## 変更

`NavigationContainer` の `onUnhandledAction` を受けて、スナックバーで知らせます。

```
画面を開けませんでした（LayoutList）
```

これで切り分けができます。

- **スナックバーが出る** → 遷移が捨てられている（JS側の問題）
- **出ないのに動かない** → 遷移は通っていて、画面が追従していない（ネイティブ側の問題）

原因の特定そのものではありませんが、押したのに動かない状態を黙って通さないという意味で、このまま残しても価値があります。

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
```

- typecheck・lint（警告77件はすべて既存分、エラーなし）・テスト231件が通過
- 文言の組み立てにテストを追加
- **リリースビルドで実際に出ることを確認しました。** 確認用に、一時的にホームの (i) を存在しない画面へ向けたビルドを作って撮影し、そのあと元に戻して入れ直しています（一時変更はコミットしていません）

| 存在しない画面へ遷移させたとき |
| --- |
| <img width="320" alt="処理されなかった遷移のスナックバー" src="https://github.com/user-attachments/assets/ec4a7328-bbcf-458a-aae8-f3c1d76ce712" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
