### PR TITLE
fix: 長押しの操作ダイアログにキャンセルを出し、選択モーダルの「＞」を外す

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,9 @@ TZ=Asia/Tokyo yarn test --runInBand
 - レイアウトの解釈は `src/print/buildPrintCommands.ts` が `PrintCommand[]` を組み立て、`src/print/executePrintCommands.ts` がプリンターへ送ります。印刷の見た目を変えるときは、この純粋関数のテストを更新します。プレビューも同じ `PrintCommand[]` を描き直すため、印刷とプレビューで解釈が分かれません。
 - スキーマを変更するときは `src/database/migrations/` に新しい版を追加します。一度入れたマイグレーションの内容は書き換えません。
 - リポジトリ層のテストは Node 同梱の `node:sqlite` に対して実際のスキーマで実行します（`src/database/__test__/testConnection.ts`）。SQLや外部キーの挙動もここで検証できます。
-- AndroidのAlertは3つまでしかボタンを表示できません。選択肢が4つ以上になり得るものは `ListPickerModal` を使います。
+- 操作や選択肢をユーザーに選ばせるAlert・ダイアログには、**選択肢の数にかかわらず必ずキャンセル（そのダイアログを閉じる手段）を用意します。** AndroidのAlertは戻るボタンでも画面外タップでも閉じられないため、キャンセルがないと、どれかを選ぶまで利用者が抜け出せません。
+- AndroidのAlertは3つまでしかボタンを表示できません。キャンセルを含めて4つ以上になるものは `ListPickerModal` を使います。このモーダルはキャンセルを常に表示し、戻るボタンでも閉じられます。
+- 選択肢がAlertに収まらないほど増えたときは、モーダルへ移す前に画面設計そのものを疑います。ダイアログを重ねて選ばせ続ける形は、一覧画面やセルの操作へ逃がせる場合が多く、増え続ける選択肢はUI/UXの問題を示す兆候です。**まず画面で表現できないかを検討してから、ダイアログを選びます。**
 - AndroidのModalは別ウィンドウのため、開いた時点で中の `TextInput` へOSがフォーカスを当てます。React Nativeは、すでにフォーカスを持っている入力欄への `focus()` をJS側で捨てる（`TextInputState.focusTextInput`）ため、ネイティブへ命令が届かず、キーボードを出す要求も送られません。`src/components/Dialog/` は一度 `blur()` で手放してから当て直しています。当て直しさえすれば、ネイティブ側（`ReactEditText.requestFocusProgrammatically`）が自分で `showSoftInput` を呼ぶので、キーボードは自動で開きます。
 - 大きな改修をPRへ分割するときは `gh stack`（`gh extension install github/gh-stack`）でスタックPRとして積み上げます。
 

--- a/src/components/Modal/ListPickerModal/index.tsx
+++ b/src/components/Modal/ListPickerModal/index.tsx
@@ -87,7 +87,7 @@ export const ListPickerModal = <T,>({
                 title={item.title}
                 description={item.description}
                 onPress={() => onSelect(item.value)}
-                accessory={item.value === selected ? 'check' : 'disclosure'}
+                accessory={item.value === selected ? 'check' : undefined}
               />
             ))}
             {!!action && (

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native'
 import type React from 'react'
-import { useCallback, useLayoutEffect, useMemo } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { StyleSheet, type ViewStyle } from 'react-native'
 import AlertAsync from 'react-native-alert-async'
 import { makeStyles } from 'react-native-swag-styles'
@@ -8,6 +8,10 @@ import { useDispatch, useSelector } from 'react-redux'
 import { MESSAGE } from '@/CONSTANTS'
 import { Cell, Section } from '@/components/List'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
+import {
+  type ListPickerItem,
+  ListPickerModal,
+} from '@/components/Modal/ListPickerModal'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, PrintData } from '@/print'
 import {
@@ -26,15 +30,28 @@ import { AppInfoButton } from './AppInfoButton'
 import { InputDialogCell } from './InputDialogCell'
 import { PrintDataCell } from './PrintDataCell'
 
+/**
+ * 印刷データを長押ししたときに選べる操作
+ */
+type PrintDataAction = 'duplicate' | 'delete'
+
+const printDataActions: ListPickerItem<PrintDataAction>[] = [
+  { value: 'duplicate', title: '複製する' },
+  { value: 'delete', title: '削除する' },
+]
+
 type Props = {}
 type ComponentProps = Props & {
   isLoading: boolean
   printData: PrintData[]
   layoutNames: Record<string, string>
+  actionTarget: PrintData | undefined
   onPressText: (text: string) => void
   onPressPrintData: (value: PrintData) => void
   onPressEditPrintData: (value: PrintData) => void
   onLongPressPrintData: (value: PrintData) => void
+  onSelectAction: (action: PrintDataAction) => void
+  onCancelAction: () => void
   onNavigateToPrinter: () => void
   onNavigateToLayoutList: () => void
 }
@@ -43,10 +60,13 @@ const Component: React.FC<ComponentProps> = ({
   isLoading,
   printData,
   layoutNames,
+  actionTarget,
   onPressText,
   onPressPrintData,
   onPressEditPrintData,
   onLongPressPrintData,
+  onSelectAction,
+  onCancelAction,
   onNavigateToPrinter,
   onNavigateToLayoutList,
 }) => {
@@ -98,6 +118,14 @@ const Component: React.FC<ComponentProps> = ({
         </Section>
       </SafeScrollView>
       <LoadingSpinner isLoading={isLoading} />
+      <ListPickerModal
+        visible={!!actionTarget}
+        title={actionTarget?.title ?? ''}
+        description="操作を選んでください"
+        items={printDataActions}
+        onSelect={onSelectAction}
+        onCancel={onCancelAction}
+      />
     </>
   )
 }
@@ -109,6 +137,10 @@ const Container: React.FC<Props> = (props) => {
   const isLoading = useSelector(selectLayoutIsLoading)
   const layouts: Layout[] = useSelector(selectLayouts)
   const printData: PrintData[] = useSelector(selectAllPrintData)
+
+  const [actionTarget, setActionTarget] = useState<PrintData | undefined>(
+    undefined,
+  )
 
   const layoutNames = useMemo(
     () => Object.fromEntries(layouts.map((layout) => [layout.id, layout.name])),
@@ -150,14 +182,22 @@ const Container: React.FC<Props> = (props) => {
     [navigation],
   )
 
-  const onLongPressPrintData = useCallback(
-    async (value: PrintData) => {
-      try {
-        const action = await AlertAsync(value.title, '操作を選んでください', [
-          { text: '複製する', onPress: () => 'duplicate' },
-          { text: '削除する', onPress: () => 'delete', style: 'destructive' },
-        ])
+  const onLongPressPrintData = useCallback((value: PrintData) => {
+    setActionTarget(value)
+  }, [])
 
+  const onCancelAction = useCallback(() => {
+    setActionTarget(undefined)
+  }, [])
+
+  const onSelectAction = useCallback(
+    async (action: PrintDataAction) => {
+      const value = actionTarget
+      setActionTarget(undefined)
+      if (!value) {
+        return
+      }
+      try {
         if (action === 'duplicate') {
           dispatch(duplicatePrintData(value))
           return
@@ -177,10 +217,10 @@ const Container: React.FC<Props> = (props) => {
           }
         }
       } catch (e: any) {
-        console.warn('onLongPressPrintData', e)
+        console.warn('onSelectAction', e)
       }
     },
-    [dispatch],
+    [actionTarget, dispatch],
   )
 
   const onNavigateToPrinter = useCallback(() => {
@@ -198,10 +238,13 @@ const Container: React.FC<Props> = (props) => {
         isLoading,
         printData,
         layoutNames,
+        actionTarget,
         onPressText,
         onPressPrintData,
         onPressEditPrintData,
         onLongPressPrintData,
+        onSelectAction,
+        onCancelAction,
         onNavigateToPrinter,
         onNavigateToLayoutList,
       }}

--- a/src/screens/LayoutEditor/ElementTypePickerModal.tsx
+++ b/src/screens/LayoutEditor/ElementTypePickerModal.tsx
@@ -53,7 +53,6 @@ export const ElementTypePickerModal: React.FC<Props> = ({
                 key={type}
                 title={describeElementType(type)}
                 onPress={() => onSelect(type)}
-                accessory="disclosure"
               />
             ))}
           </ScrollView>

--- a/src/screens/PrintDataList/index.tsx
+++ b/src/screens/PrintDataList/index.tsx
@@ -20,6 +20,10 @@ import { COLOR, MESSAGE } from '@/CONSTANTS'
 import { InputDialog } from '@/components/Dialog'
 import { Cell, Section } from '@/components/List'
 import { LoadingSpinner } from '@/components/LoadingSpinner'
+import {
+  type ListPickerItem,
+  ListPickerModal,
+} from '@/components/Modal/ListPickerModal'
 import { SafeScrollView } from '@/components/SafeScrollView'
 import type { Layout, PrintData } from '@/print'
 import { createPrintData } from '@/print'
@@ -40,14 +44,28 @@ import { styleType } from '@/utils/styles'
 
 type ParamsProps = RouteProp<MainParams, 'PrintDataList'>
 
+/**
+ * 印刷データを長押ししたときに選べる操作
+ */
+type PrintDataAction = 'print' | 'duplicate' | 'delete'
+
+const printDataActions: ListPickerItem<PrintDataAction>[] = [
+  { value: 'print', title: '印刷する' },
+  { value: 'duplicate', title: '複製する' },
+  { value: 'delete', title: '削除する' },
+]
+
 type Props = {}
 type ComponentProps = Props & {
   isLoading: boolean
   layout: Layout | undefined
   printData: PrintData[]
   isDialogVisible: boolean
+  actionTarget: PrintData | undefined
   onPressPrintData: (value: PrintData) => void
   onLongPressPrintData: (value: PrintData) => void
+  onSelectAction: (action: PrintDataAction) => void
+  onCancelAction: () => void
   onPressAdd: () => void
   onSubmitTitle: (title: string) => void
   onCancelDialog: () => void
@@ -58,8 +76,11 @@ const Component: React.FC<ComponentProps> = ({
   layout,
   printData,
   isDialogVisible,
+  actionTarget,
   onPressPrintData,
   onLongPressPrintData,
+  onSelectAction,
+  onCancelAction,
   onPressAdd,
   onSubmitTitle,
   onCancelDialog,
@@ -117,6 +138,14 @@ const Component: React.FC<ComponentProps> = ({
         onPress={onSubmitTitle}
         onCancel={onCancelDialog}
       />
+      <ListPickerModal
+        visible={!!actionTarget}
+        title={actionTarget?.title ?? ''}
+        description="操作を選んでください"
+        items={printDataActions}
+        onSelect={onSelectAction}
+        onCancel={onCancelAction}
+      />
     </>
   )
 }
@@ -139,6 +168,9 @@ const Container: React.FC<Props> = (props) => {
   const isLoading = useSelector(selectPrintDataIsLoading)
 
   const [isDialogVisible, setIsDialogVisible] = useState<boolean>(false)
+  const [actionTarget, setActionTarget] = useState<PrintData | undefined>(
+    undefined,
+  )
 
   useLayoutEffect(() => {
     navigation.setOptions({ title: '印刷データ' })
@@ -154,15 +186,22 @@ const Container: React.FC<Props> = (props) => {
     [layoutId, navigation],
   )
 
-  const onLongPressPrintData = useCallback(
-    async (value: PrintData) => {
-      try {
-        const action = await AlertAsync(value.title, '操作を選んでください', [
-          { text: '印刷する', onPress: () => 'print' },
-          { text: '複製する', onPress: () => 'duplicate' },
-          { text: '削除する', onPress: () => 'delete', style: 'destructive' },
-        ])
+  const onLongPressPrintData = useCallback((value: PrintData) => {
+    setActionTarget(value)
+  }, [])
 
+  const onCancelAction = useCallback(() => {
+    setActionTarget(undefined)
+  }, [])
+
+  const onSelectAction = useCallback(
+    async (action: PrintDataAction) => {
+      const value = actionTarget
+      setActionTarget(undefined)
+      if (!value) {
+        return
+      }
+      try {
         if (action === 'print') {
           dispatch(printLayout({ layoutId, printDataId: value.id }))
           return
@@ -187,10 +226,10 @@ const Container: React.FC<Props> = (props) => {
           }
         }
       } catch (e: any) {
-        console.warn('onLongPressPrintData', e)
+        console.warn('onSelectAction', e)
       }
     },
-    [dispatch, layoutId],
+    [actionTarget, dispatch, layoutId],
   )
 
   const onPressAdd = useCallback(() => setIsDialogVisible(true), [])
@@ -220,8 +259,11 @@ const Container: React.FC<Props> = (props) => {
         layout,
         printData,
         isDialogVisible,
+        actionTarget,
         onPressPrintData,
         onLongPressPrintData,
+        onSelectAction,
+        onCancelAction,
         onPressAdd,
         onSubmitTitle,
         onCancelDialog,


### PR DESCRIPTION
## 概要

長押しで出る操作ダイアログにキャンセルがなく、選択モーダルの未選択セルに意味のない「＞」が付いていた問題を直します。

- ホームと印刷データ一覧の長押しは `Alert` で操作を選ばせていたため、キャンセルがありませんでした。実機で確認したところ、**戻るボタンでも画面外タップでも閉じられず、複製・削除のどちらかを選ぶまで抜けられない**状態でした。印刷データ一覧は選択肢が3つあり、Alertのボタン上限からキャンセルを足せません。どちらも `ListPickerModal` へ移し、キャンセルを常に出します。
- `ListPickerModal` と `ElementTypePickerModal` は、未選択のセルに遷移を表す「＞」を付けていました。タップしても画面遷移はせず、選択済みを表すチェックとも紛らわしいため外します。
- 同じことを繰り返さないよう、選択ダイアログにはキャンセルを必須とする方針と、選択肢が増えたらダイアログより先に画面設計を疑う指針を `AGENTS.md` に残します。

## 変更前後

### ホームの長押し

| 変更前 | 変更後 |
| --- | --- |
| ![変更前](https://github.com/user-attachments/assets/13c90486-9678-49c9-be73-a091a8b720da) | ![変更後](https://github.com/user-attachments/assets/971ca08c-5e9e-4095-871e-3266e2085b32) |

### 印刷データ一覧の長押し

| 変更前 | 変更後 |
| --- | --- |
| ![変更前](https://github.com/user-attachments/assets/c01eacba-771e-4ad0-9f91-635a41f1a37b) | ![変更後](https://github.com/user-attachments/assets/323c8175-1e4e-43d5-a6a6-3a6c49a3e6ba) |

### 要素の追加

| 変更前 | 変更後 |
| --- | --- |
| ![変更前](https://github.com/user-attachments/assets/3d0abe39-7d88-4259-812c-e8f26c6526cf) | ![変更後](https://github.com/user-attachments/assets/5823124c-d0c3-41b4-9dfa-e733cc6988c5) |

### 内容の決め方

| 変更前 | 変更後 |
| --- | --- |
| ![変更前](https://github.com/user-attachments/assets/2ac4ef00-9bc9-4b97-b583-989b35ab0403) | ![変更後](https://github.com/user-attachments/assets/55a1033a-169e-4e34-a5be-cfa94a85fd97) |

削除を選んだときは、モーダルが閉じてから確認のAlertが手前に出ます。

![削除の確認](https://github.com/user-attachments/assets/5bfd6085-f40a-4ea4-b7df-5e1b25b0650b)

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
(cd android && ./gradlew assembleRelease)
```

- `yarn typecheck` 成功。
- `yarn lint` 成功（既存の警告のみで、変更箇所に新規の指摘なし）。
- `TZ=Asia/Tokyo yarn test --runInBand` は 22 suites / 231 tests すべて成功。
- `./gradlew assembleRelease` 成功。

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- 変更前は `main` をビルドして撮影しました。
- ホーム・印刷データ一覧の長押しでモーダルが開き、キャンセルで閉じることを確認しました。
- 戻るボタンでもモーダルが閉じることを確認しました。
- 削除を選ぶとモーダルが閉じ、確認のAlertが手前に表示されること、「いいえ」で削除されないことを確認しました。
- 複製と削除の実行、印刷は保存データを変えるため実施していません。

## 補足

- レイアウト一覧（`src/screens/LayoutList/`）の長押しはAlertのままですが、キャンセルを持つため今回の対象から外しています。選択肢が増えるならモーダルへ移す想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
