### PR TITLE
fix: レイアウト削除後に印刷データがホームへ残る

### DIFF
--- a/src/redux/modules/layout/saga/__test__/layoutSaga.test.ts
+++ b/src/redux/modules/layout/saga/__test__/layoutSaga.test.ts
@@ -3,8 +3,10 @@ import { call } from 'redux-saga/effects'
 import { expectSaga } from 'redux-saga-test-plan'
 import type { StaticProvider } from 'redux-saga-test-plan/providers'
 import * as database from '@/database'
-import type { Layout } from '@/print'
+import type { Layout, LayoutField } from '@/print'
+import { assignPrintData } from '@/redux/modules/printData/slice'
 import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
+import type { RootState } from '@/redux/RootState'
 import {
   assignIsLoading,
   assignLayouts,
@@ -37,6 +39,19 @@ const layout: Layout = {
 }
 
 const connection = {} as database.SqliteConnection
+
+const field: LayoutField = {
+  id: 'field-1',
+  key: 'name',
+  label: '名前',
+  valueType: 'text',
+}
+
+/**
+ * `saveLayoutSaga` は保存前のレイアウトを Redux から読む
+ */
+const stateWith = (layouts: Layout[]): RootState =>
+  ({ layout: { layouts, isLoading: false } }) as RootState
 
 const provideDatabase = (layouts: Layout[] = [layout]): StaticProvider[] => [
   [call(database.getDatabase), connection],
@@ -85,6 +100,7 @@ describe('layoutSaga saveLayout', () => {
   it('保存してから読み直す', () => {
     const save = jest.fn()
     return expectSaga(layoutSaga)
+      .withState(stateWith([layout]))
       .provide([
         [call(database.getDatabase), connection],
         {
@@ -170,6 +186,9 @@ describe('layoutSaga deleteLayout', () => {
             if (fn === database.findAllLayouts) {
               return []
             }
+            if (fn === database.findAllPrintData) {
+              return []
+            }
             return next()
           },
         },
@@ -181,4 +200,79 @@ describe('layoutSaga deleteLayout', () => {
         expect(remove).toHaveBeenCalledWith(layout.id)
       })
   })
+
+  it('印刷データも読み直す', () =>
+    expectSaga(layoutSaga)
+      .provide([
+        [call(database.getDatabase), connection],
+        {
+          call({ fn }, next) {
+            if (fn === database.deleteLayout) {
+              return undefined
+            }
+            if (fn === database.findAllLayouts) {
+              return []
+            }
+            if (fn === database.findAllPrintData) {
+              return []
+            }
+            return next()
+          },
+        },
+      ])
+      .put(assignPrintData([]))
+      .dispatch(deleteLayout(layout))
+      .silentRun())
+})
+
+describe('layoutSaga saveLayout と印刷データ', () => {
+  const withField: Layout = { ...layout, fields: [field] }
+
+  it('入力項目が減ったら印刷データを読み直す', () =>
+    expectSaga(layoutSaga)
+      .withState(stateWith([withField]))
+      .provide([
+        [call(database.getDatabase), connection],
+        {
+          call({ fn }, next) {
+            if (fn === database.saveLayout) {
+              return undefined
+            }
+            if (fn === database.findAllLayouts) {
+              return []
+            }
+            if (fn === database.findAllPrintData) {
+              return []
+            }
+            return next()
+          },
+        },
+      ])
+      .put(assignPrintData([]))
+      .dispatch(saveLayout({ ...withField, fields: [] }))
+      .silentRun())
+
+  it('入力項目が減らなければ印刷データは読み直さない', () =>
+    expectSaga(layoutSaga)
+      .withState(stateWith([withField]))
+      .provide([
+        [call(database.getDatabase), connection],
+        {
+          call({ fn }, next) {
+            if (fn === database.saveLayout) {
+              return undefined
+            }
+            if (fn === database.findAllLayouts) {
+              return []
+            }
+            if (fn === database.findAllPrintData) {
+              return []
+            }
+            return next()
+          },
+        },
+      ])
+      .not.put(assignPrintData([]))
+      .dispatch(saveLayout({ ...withField, name: '名刺2' }))
+      .silentRun())
 })

--- a/src/redux/modules/layout/saga/index.ts
+++ b/src/redux/modules/layout/saga/index.ts
@@ -1,4 +1,4 @@
-import { call, put, takeEvery, takeLeading } from 'redux-saga/effects'
+import { call, put, select, takeEvery, takeLeading } from 'redux-saga/effects'
 import {
   deleteLayout as deleteLayoutFromDatabase,
   findAllLayouts,
@@ -7,7 +7,9 @@ import {
   saveLayout as saveLayoutToDatabase,
 } from '@/database'
 import { duplicateLayout as duplicateLayoutValue, type Layout } from '@/print'
+import { reloadPrintDataSaga } from '@/redux/modules/printData/saga'
 import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
+import { selectLayoutById } from '../selectors'
 import {
   assignIsLoading,
   assignLayouts,
@@ -49,9 +51,21 @@ function* fetchLayoutsSaga() {
 
 function* saveLayoutSaga({ payload }: ReturnType<typeof saveLayout>) {
   try {
+    const previous: Layout | undefined = yield select(
+      selectLayoutById(payload.id),
+    )
     const db: SqliteConnection = yield call(getDatabase)
     yield call(saveLayoutToDatabase, db, payload)
     yield call(reloadLayoutsSaga)
+
+    // 入力項目を消すと、その値は印刷データから連鎖削除される。
+    // Redux の写しが古いままだと、消えた値が入力欄に残る。
+    const removedField = previous?.fields.some(
+      (field) => !payload.fields.some(({ id }) => id === field.id),
+    )
+    if (removedField) {
+      yield call(reloadPrintDataSaga)
+    }
   } catch (e: any) {
     console.warn('saveLayoutSaga', e)
     yield put(enqueueSnackbar({ message: `レイアウトの保存に失敗しました` }))
@@ -79,6 +93,10 @@ function* deleteLayoutSaga({ payload }: ReturnType<typeof deleteLayout>) {
     const db: SqliteConnection = yield call(getDatabase)
     yield call(deleteLayoutFromDatabase, db, payload.id)
     yield call(reloadLayoutsSaga)
+
+    // レイアウトを消すと、その印刷データも連鎖削除される。
+    // 読み直さないと、消えたはずの印刷データがホームに残る。
+    yield call(reloadPrintDataSaga)
   } catch (e: any) {
     console.warn('deleteLayoutSaga', e)
     yield put(enqueueSnackbar({ message: `レイアウトの削除に失敗しました` }))

--- a/src/redux/modules/printData/saga/index.ts
+++ b/src/redux/modules/printData/saga/index.ts
@@ -30,8 +30,13 @@ export function* printDataSaga() {
 
 /**
  * SQLite を情報源として、Redux の写しを作り直す
+ *
+ * レイアウト側の操作でも印刷データが消えることがあるため、
+ * `@package` として layoutSaga からも呼ぶ。
+ *
+ * @package
  */
-function* reloadPrintDataSaga() {
+export function* reloadPrintDataSaga() {
   const db: SqliteConnection = yield call(getDatabase)
   const values: PrintData[] = yield call(findAllPrintData, db)
   yield put(assignPrintData(values))


### PR DESCRIPTION
## 概要

レイアウトを削除しても、そのレイアウトの印刷データがホームに残り続けます。次にアプリを起動すると消えるため、利用者からは「印刷データが勝手に消えた」ように見えます。

SQLite は外部キーの連鎖削除で印刷データまで消しています（確認ダイアログの文言どおり）。ところが `deleteLayoutSaga` はレイアウトしか読み直していませんでした。

```ts
yield call(deleteLayoutFromDatabase, db, payload.id)
yield call(reloadLayoutsSaga)   // 印刷データは読み直していない
```

残った行はレイアウト名の欄が空になり、そのまま印刷や編集を選べてしまいます。印刷を選ぶと「レイアウトが見つかりませんでした」で止まります。

入力項目を削除したときも同じです。`print_data_values.field_id` は `layout_fields` を `ON DELETE CASCADE` で参照しているため、入力項目を消すと印刷データに入れた値も消えますが、Redux の写しには残っていました。

## 変更内容

- `reloadPrintDataSaga` を `@package` として公開し、レイアウト側からも呼べるようにする
- `deleteLayoutSaga` … レイアウト削除後に印刷データも読み直す
- `saveLayoutSaga` … 保存前後で入力項目が減った場合だけ印刷データを読み直す。要素の設定を変えるたびに保存が走るため、無条件には読み直さない
- 上記3件のテストを追加

## 変更前後

一時レイアウトに印刷データ「test」を作り、そのレイアウトを削除した直後のホームです。

| 変更前 | 変更後 |
| --- | --- |
| ![変更前](https://github.com/user-attachments/assets/e6405fe8-f285-4b8f-b48b-6d966d982c54) | ![変更後](https://github.com/user-attachments/assets/84b72e96-e01a-40d4-bdf4-5277e489c97b) |

変更前は、消えたはずの「test」がレイアウト名なしで残っています。変更後はその場で消えます。

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
(cd android && ./gradlew assembleRelease)
```

- `yarn typecheck` 成功。
- `yarn lint` 成功。
- `TZ=Asia/Tokyo yarn test --runInBand` は 22 suites / 234 tests すべて成功。sagaのテストを3件追加しました。`saveLayout` のテストは saga が保存前のレイアウトを Redux から読むようになったため、`withState` を足しています。
- `./gradlew assembleRelease` 成功。

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- 変更前は `main` をビルドして撮影しました。
- 撮影用に一時レイアウトと印刷データを作り、そのレイアウトを削除して挙動を比べました。既存のデータには触れていません。一時レイアウトは撮影の過程で削除済みです。
- レイアウト名が「ｔｍｐ」なのは、`adb` からの入力が日本語IMEで変換されたためです。
- 入力項目を削除したときの読み直しは、テストでのみ確認しています。
- 印刷は行っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
