### PR TITLE
fix: 印刷が固まると以後の印刷が無反応になり続けるのを直す

### DIFF
--- a/src/redux/modules/printData/saga/__test__/printLayout.test.ts
+++ b/src/redux/modules/printData/saga/__test__/printLayout.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from '@jest/globals'
+import { call } from 'redux-saga/effects'
+import { expectSaga } from 'redux-saga-test-plan'
+import type { Layout, PrintData } from '@/print'
+import { validatePrinterSaga } from '@/redux/modules/printer/saga/printerSagaUtils'
+import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
+import type { RootState } from '@/redux/RootState'
+import { printLayout } from '../../slice'
+import { printLayoutSaga } from '../printLayout'
+
+const layout: Layout = {
+  id: 'layout-1',
+  name: '名刺',
+  fields: [],
+  elements: [
+    {
+      id: 'text-1',
+      type: 'text',
+      source: { kind: 'static', value: '織田信長' },
+      fontSize: 24,
+      bold: false,
+      underline: false,
+      alignment: 'center',
+      hideWhenEmpty: true,
+    },
+  ],
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+const printData: PrintData = {
+  id: 'print-1',
+  layoutId: 'layout-1',
+  title: 'サンプル',
+  values: {},
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+const state = {
+  layout: { layouts: [layout], isLoading: false },
+  printData: { printData: [printData], isLoading: false },
+} as RootState
+
+const action = printLayout({ layoutId: 'layout-1', printDataId: 'print-1' })
+
+const timeoutMessage =
+  '印刷が終わりませんでした。プリンターの状態を確認してください'
+
+describe('printLayoutSaga', () => {
+  it('印刷が終わったら何も知らせない', () =>
+    expectSaga(printLayoutSaga, action)
+      .withState(state)
+      .provide([
+        [call(validatePrinterSaga), true],
+        { race: () => ({ done: undefined }) },
+      ])
+      .not.put(enqueueSnackbar({ message: timeoutMessage }))
+      .run())
+
+  /**
+   * プリンターが応答しないまま終わらないと、`takeLeading` が以後の印刷を
+   * 捨て続ける。時間で切り上げて知らせることを確かめる。
+   */
+  it('印刷が終わらなければ知らせて、サーガを終わらせる', () =>
+    expectSaga(printLayoutSaga, action)
+      .withState(state)
+      .provide([
+        [call(validatePrinterSaga), true],
+        { race: () => ({ isTimeout: true }) },
+      ])
+      .put(enqueueSnackbar({ message: timeoutMessage }))
+      .run())
+
+  it('プリンターが使えなければ印刷しない', () =>
+    expectSaga(printLayoutSaga, action)
+      .withState(state)
+      .provide([[call(validatePrinterSaga), false]])
+      .not.put(enqueueSnackbar({ message: timeoutMessage }))
+      .run())
+})

--- a/src/redux/modules/printData/saga/printLayout.ts
+++ b/src/redux/modules/printData/saga/printLayout.ts
@@ -1,4 +1,4 @@
-import { call, put, select } from 'redux-saga/effects'
+import { call, delay, put, race, select } from 'redux-saga/effects'
 import type { Layout, PrintCommand, PrintData } from '@/print'
 import { buildPrintCommands, executePrintCommands } from '@/print'
 import { selectLayouts } from '@/redux/modules/layout/selectors'
@@ -6,6 +6,17 @@ import { validatePrinterSaga } from '@/redux/modules/printer/saga/printerSagaUti
 import { enqueueSnackbar } from '@/redux/modules/snackbar/slice'
 import { selectAllPrintData } from '../selectors'
 import type { printLayout } from '../slice'
+
+/**
+ * 印刷の実行を待つ上限（ミリ秒）
+ *
+ * @note
+ * プリンターは、バッファへ入ったあとに応答が返らないと固まることがある
+ * （`executePrintCommands` の注記を参照）。`printLayout` は `takeLeading`
+ * で受けているため、このサーガが終わらないと以後の印刷が黙って捨てられ、
+ * アプリを再起動するまで印刷できなくなる。時間で切り上げて次を受け付ける。
+ */
+const PRINT_TIMEOUT = 15000
 
 /**
  * @package
@@ -48,7 +59,17 @@ export function* printLayoutSaga({ payload }: ReturnType<typeof printLayout>) {
       return
     }
 
-    yield call(executePrintCommands, commands)
+    const { isTimeout }: { isTimeout?: true } = yield race({
+      done: call(executePrintCommands, commands),
+      isTimeout: delay(PRINT_TIMEOUT),
+    })
+    if (isTimeout) {
+      yield put(
+        enqueueSnackbar({
+          message: `印刷が終わりませんでした。プリンターの状態を確認してください`,
+        }),
+      )
+    }
   } catch (e: any) {
     console.warn('printLayoutSaga', e)
     yield put(enqueueSnackbar({ message: `印刷に失敗しました` }))


### PR DESCRIPTION
## 概要

印刷が一度でも終わらなくなると、**それ以降の印刷タップがすべて黙って無視され、アプリを再起動するまで印刷できなくなります。** メッセージも出ないため、利用者からは壊れたように見えます。

原因は2つの噛み合わせです。

**1. `takeLeading` は実行中のサーガが終わるまで後続を捨てる**

```ts
yield takeLeading(printLayout, printLayoutSaga)
```

二重印刷を防ぐための指定ですが、サーガが完了しない限り解放されません。

**2. プリンターは応答が返らないと固まることがある**

`executePrintCommands` の注記にあるとおりです。

> 用紙幅をプリンターへ問い合わせる。バッファへ入ったあとは応答が返らず固まるため、入る前に呼ぶこと。

区切り線の分は対策済みですが、バッファの開閉や送信の途中で応答が返らなければ `executePrintCommands` の Promise は解決しません。すると `printLayoutSaga` が終わらず、`takeLeading` が永久に閉じたままになります。

遷移や保存は別経路なので動き続けるため、「印刷だけ無反応」という分かりにくい壊れ方をします。

## 変更内容

印刷の実行を `race` で見張り、15秒で切り上げます。切り上げたら理由を伝え、サーガを終わらせて次の印刷を受け付けられるようにします。

```ts
const { isTimeout } = yield race({
  done: call(executePrintCommands, commands),
  isTimeout: delay(PRINT_TIMEOUT),
})
```

サーガのテストを3件追加しました。

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
(cd android && ./gradlew assembleRelease)
```

- `yarn typecheck` 成功。
- `yarn lint` 成功。
- `TZ=Asia/Tokyo yarn test --runInBand` は 23 suites / 240 tests すべて成功。
- `./gradlew assembleRelease` 成功。

### 実機確認（SUNMI V2_PRO / Android 7.1.2）

- ビルドを入れて起動を確認しました。画面の見た目は変わらないため、対応前後のスクリーンショットはありません。
- **タイムアウトの経路そのものは実機で確認できていません。** プリンターを意図的に固まらせる手段がないためです。分岐の動きはテストで確認しています。
- 印刷は行っていません。実際に印刷して確かめる場合は、紙が出るためご判断ください。

## 残る課題

- 切り上げた時点で `enterBuffer` のままになっている可能性があります。その状態では次の印刷も応答が返らず、またタイムアウトになることが考えられます。**黙って無反応になり続ける状態は解消されますが**、プリンター側の復帰までは面倒を見ていません。バッファの後始末は別途検討します。
- 15秒という値は、画像を含む印刷でも足りる想定で置いた見積もりです。実機で長い印刷を試して、短すぎるようなら調整します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
