### PR TITLE
docs: クリーンビルドは2回に分けると書く

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,20 @@
 - JavaScript・TypeScript・JSONなど、Biomeが対応するファイルの検査と整形にはBiomeを使用します。確認は `yarn lint`、自動修正と整形は `yarn lint-force` で実行します。
 - Android開発にはJDK 17と、`android/build.gradle` に定義されたAndroid SDK・NDKを使用します。
 - Gradleはリポジトリの `android/gradlew` を使用します。
+- `clean` と `assembleDebug`・`assembleRelease` を1回の実行にまとめません。**`clean` はオートリンクで参加している `node_modules` 内のライブラリのビルド出力まで消すため、prefab が消えたままのディレクトリを読みに行って失敗します。** ネイティブを持つライブラリ（`react-native-reanimated` など）で起きます。
+
+```
+Error: invalid value for <package_path>: directory
+".../node_modules/react-native-reanimated/android/build/intermediates/prefab_package/release/prefab"
+is not readable.
+```
+
+- 作り直すときは2回に分けて実行します。
+
+```sh
+(cd android && ./gradlew clean)
+(cd android && ./gradlew assembleRelease)
+```
 
 ## 必須の検証
 


### PR DESCRIPTION
## 概要

`./gradlew clean assembleRelease` は失敗します。踏むたびに調べ直すことになるため、理由と回避方法を `AGENTS.md` に残します。

```
Error: invalid value for <package_path>: directory
".../node_modules/react-native-reanimated/android/build/intermediates/prefab_package/release/prefab"
is not readable.
```

`clean` は `android/` 配下だけでなく、**オートリンクでGradleのサブプロジェクトとして参加している `node_modules` 内のライブラリのビルド出力も消します。** 一方 `assembleRelease` の途中で走る prefab は、それらのライブラリが出力するディレクトリをパスとして受け取ります。同じ実行に並べると受け渡しが噛み合わず、消えたままのディレクトリを読みに行って落ちます。

`org.gradle.parallel` は無効なので、並列実行が原因ではありません。

## 変更内容

`AGENTS.md` の「開発環境」に、`clean` と `assemble*` を1回の実行にまとめないことと、2回に分ける手順を書きました。

```sh
(cd android && ./gradlew clean)
(cd android && ./gradlew assembleRelease)
```

## 検証

- 分けて実行すれば通ることを確認しました。`./gradlew clean` が 3秒、`./gradlew assembleRelease` が 8分22秒、いずれも BUILD SUCCESSFUL でした。
- まとめて実行すると、上のエラーで BUILD FAILED になります。
- ドキュメントのみの変更のため、差分とリンクを確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
