### PR TITLE
fix: ライセンス詳細を開いた直後に上端から見せる

### DIFF
--- a/src/screens/LicenseDetail/index.tsx
+++ b/src/screens/LicenseDetail/index.tsx
@@ -65,7 +65,15 @@ const Component: React.FC<ComponentProps> = ({ license, onPressHomepage }) => {
       </Section>
       <Section title="ライセンス本文">
         <View style={styles.textContainer}>
-          <Text style={styles.text} selectable={true}>
+          {/*
+            本文は選択できるようにしない。Androidでは選択できる文字がタッチ
+            操作でもフォーカスを取り、ScrollViewがそこまで送ってしまうため、
+            画面を開いた直後に上のパッケージ情報が見えなくなる端末がある
+            （SUNMI V2 PRO / Android 7.1.2 で再現。V2s では起きない）。
+            描画のあとで有効にしても、有効にした時点でフォーカスが移るため
+            変わらない。読むための画面なので、選択より位置を優先する。
+          */}
+          <Text style={styles.text}>
             {licenseText ??
               'このパッケージはライセンス本文を同梱していません。ホームページを参照してください。'}
           </Text>


### PR DESCRIPTION
## 概要

ライセンスの詳細を開くと、**本文の途中から始まり、上にあるバージョン・ライセンス・作者・ホームページが画面の外**にありました。スクロールして戻らないと見えません。

原因は本文の `selectable={true}` です。Androidでは選択できる文字がタッチ操作でもフォーカスを取れるようになり、`ScrollView` がフォーカスした子まで送ってしまいます。

端末によって出方が違います。**SUNMI V2 PRO（Android 7.1.2）では再現し、V2s では起きません。**

## 試したこと

位置とテキスト選択の両方を残せないか、実機で2つ試しましたが、どちらも効きませんでした。

| 方法 | 結果 |
| --- | --- |
| `onContentSizeChange` で `scrollTo({ y: 0 })` | 効かない。フォーカスによるスクロールが後に来て上書きされる |
| `requestAnimationFrame` のあとで `selectable` を有効にする | 効かない。有効にした時点でフォーカスが移る |

`InteractionManager` はこのReact Nativeのバージョンではcoreから削除済みのため使えませんでした。

読むための画面なので、**選択より位置を優先して `selectable` をやめます。** 本文をコピーしたい場合は、同じ画面の「ホームページ」から原典をたどれます。

## 変更前後

| 変更前 | 変更後 |
| --- | --- |
| ![変更前](https://github.com/user-attachments/assets/9caee41e-0be2-477a-8d1f-9890217f8034) | ![変更後](https://github.com/user-attachments/assets/59e6f6e9-b9d6-4c3b-9b40-df71a7df0ab9) |

## 検証

```sh
yarn typecheck
yarn lint
TZ=Asia/Tokyo yarn test --runInBand
(cd android && ./gradlew assembleRelease)
```

- `yarn typecheck` 成功。
- `yarn lint` 成功。
- `TZ=Asia/Tokyo yarn test --runInBand` は 23 suites / 240 tests すべて成功。
- `./gradlew assembleRelease` 成功。

### 実機確認（SUNMI V2 PRO / Android 7.1.2）

- ライセンス詳細を開くと、パッケージの情報が最初から見えることを確認しました。
- V2s では元から上端で開くため、この変更で位置が変わることはありません。

## 補足

- 本文のコピーを残したい場合は、クリップボードへコピーするセルを置く方法があります。React Native の core から `Clipboard` は削除されているため依存の追加が必要で、今回は入れていません。必要でしたら別途対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
