### PR TITLE
chore(dependabot): 更新グループを実際の依存関係に合わせて見直す

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,27 +7,58 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'main'
     open-pull-requests-limit: 10
     schedule:
       interval: 'weekly'
+    # グループはマッチした最初のものが採用される。順序に意味がある。
     groups:
+      # React Nativeのテンプレート一式。互換セットとしてまとめる。
+      # このグループのPRはそのままマージしない。新しいバージョンが出たことに
+      # 気づくための通知として扱う。実際の更新は依存ライブラリの対応状況を確認し、
+      # Upgrade Helperとrn-diff-purgeを基準に android/ のテンプレート差分まで含めて
+      # 手作業で行う（AGENTS.md「React Native・依存関係の更新」を参照）。
+      update-react-native:
+        patterns:
+          - 'react-native'
+          - '@react-native/*'
+          - '@react-native-community/cli'
+          - '@react-native-community/cli-*'
+      # Reactとテスト用レンダラ、型定義はバージョンを揃える。
+      update-react:
+        patterns:
+          - 'react'
+          - 'react-test-renderer'
+          - '@types/react'
+          - '@types/react-test-renderer'
+      # babel-jest はbabelではなくjestのバージョンに追従するため、babelより前に置く。
+      update-jest:
+        patterns:
+          - 'jest'
+          - 'jest-*'
+          - '@jest/*'
+          - '@types/jest'
+          - 'babel-jest'
+          - 'ts-jest'
       update-redux:
         patterns:
           - '@reduxjs/toolkit'
           - 'redux'
           - 'redux-*'
+          - '@redux-saga/*'
           - 'react-redux'
           - 'reselect'
-      update-textlint:
-        patterns:
-          - 'textlint'
-          - 'textlint-*'
       update-babel:
         patterns:
           - 'babel'
           - '@babel/*'
           - 'babel-*'
+      update-react-navigation:
+        patterns:
+          - '@react-navigation/*'
+      # 上のグループに入らなかった残りの型定義。
+      update-types:
+        patterns:
+          - '@types/*'
     # React Native 0.87 は Babel 8 に対応していない。
     # @react-native/babel-preset が @babel/core ^7 を前提としており、8系にすると
     # テストが動かず、リリースのJSバンドルも作れなくなる。
@@ -38,6 +69,5 @@ updates:
           - 'version-update:semver-major'
   - package-ecosystem: 'github-actions'
     directory: '/'
-    target-branch: 'main'
     schedule:
       interval: 'monthly'


### PR DESCRIPTION
## 変更概要

`.github/dependabot.yml` のグループ設定を、実際の `package.json` とこれまでのDependabot PRの出方に合わせて見直しました。対象は npm のみで、github-actions のグループ化は今回見送っています。

### グループの追加・修正

| グループ | 変更 | 理由 |
| --- | --- | --- |
| `update-textlint` | 削除 | textlint系の依存関係が1つも残っていない |
| `update-react-native` | 追加 | `react-native` / `@react-native/*` / `@react-native-community/cli*` は同じバージョンで連動する |
| `update-react` | 追加 | #496 と #497 で `react-test-renderer` と `react` が同じ 19.2.8 なのに別PRで来ていた |
| `update-jest` | 追加 | jest本体・`jest-*`・`ts-jest`・`@types/jest` はjestのメジャーで一斉に動く |
| `update-redux` | `@redux-saga/*` を追加 | スコープ付きのため `redux-*` にマッチせず、`@redux-saga/is` などを取りこぼしていた |
| `update-react-navigation` | 追加 | `@react-navigation/*` は連動してリリースされる |
| `update-types` | 追加 | 上のグループに入らない残りの型定義。#495 で `@types/node` が単独のメジャー更新PRになっていた |

グループはマッチした最初のものが採用されるため、順序に意味があります。`babel-jest` はbabelではなくjestのバージョンに追従するので、`update-jest` を `update-babel` より前に置いています。

`@react-native-async-storage/*` や `@react-native-segmented-control/*` を巻き込まないよう、RNグループのパターンは `@react-native*` ではなく `@react-native/*` と `@react-native-community/cli*` に限定しています。

### `target-branch` の削除

指定先がデフォルトブランチの `main` と同じで冗長です。加えて[公式ドキュメント](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)に次の記載があります。

> All options marked with a security updates icon also change how Dependabot creates pull requests for security updates, except where `target-branch` is used.

`ignore` はこのマークが付くオプションのため、`target-branch` を書いているせいで `@babel/*` のメジャー除外がセキュリティ更新PRに適用されていませんでした。Babel 8 が入るとRN 0.87でテストもリリースバンドルも壊れるので、この条件は効いている必要があります。

### React Nativeグループの扱い

DependabotのPRは `package.json` と `yarn.lock` しか触らず、`android/` のテンプレート差分は入りません。このグループのPRはそのままマージせず、新しいバージョンが出たことに気づくための通知として扱う方針です。実際の更新は依存ライブラリの対応状況を確認したうえで、Upgrade Helperと rn-diff-purge を基準に手作業で行います。設定ファイルにもコメントとして残しました。

### 今回やらないこと

- github-actions のグループ化。actionごとに個別PRが立つ状態のままにします。
- ルートの `Gemfile` に対する `bundler` のentry追加。React Nativeの更新時に触る程度のため入れていません。

## 検証

YAMLの構文確認と、実際の `package.json` に対する振り分けのシミュレーションを行いました。

```
YAML OK
  npm groups= 7 target-branch= (none)
  github-actions groups= 0 target-branch= (none)
```

43パッケージが7グループに振り分けられます。

| グループ | 数 |
| --- | --- |
| `update-react-native` | 8 |
| `update-react` | 4 |
| `update-jest` | 9 |
| `update-redux` | 10 |
| `update-babel` | 7 |
| `update-react-navigation` | 2 |
| `update-types` | 3 |

残る30個は `dayjs` や `react-native-screens` など互いに独立したライブラリで、個別PRのままです。

## 未実施

- `yarn typecheck` / `yarn lint` / `yarn test` / `assembleDebug` は実行していません。CI設定ファイルのみの変更で、JavaScript・TypeScript・ネイティブのコードに変更がないためです。
- 実機での動作確認はありません。アプリの挙動に影響しない変更です。
- グループ名を変更したことで、既存の `update-babel` グループのオープンPRがあれば一度クローズされて作り直されます（ブランチ名にグループ名が含まれるため）。
- 設定が意図通りに効いているかは、次回のDependabot実行でPRの立ち方を見て確認する必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
