### PR TITLE
ci(publish): リリースビルドでランナーが落ちる問題に対処する

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,10 @@ jobs:
   build:
     name: Publish
     runs-on: ubuntu-latest
+    # 固まったときにGitHubのジョブ上限（6時間）まで走らせない。
+    # 落ちるとログが残らず原因を追えないため、早めに打ち切る。
+    # CIのassembleDebugが約21分、releaseはそれより重いので倍を見込む。
+    timeout-minutes: 60
 
     env:
       # タグを打った場合はそのタグ、手動実行では入力されたタグ（空になり得る）
@@ -89,8 +93,13 @@ jobs:
       # 有効にするなら指摘の棚卸しから始める
 
       # 製品版ではないため、リリースビルドもコミット済みの debug キーストアで署名する
+
+      # 4 ABI すべてをビルドするとネイティブのコンパイルがランナーのメモリを使い切り、
+      # ランナーごと落ちる（The hosted runner lost communication with the server）。
+      # 配布先のSUNMI端末はARMのため、エミュレータ用のx86とx86_64は作らない。
+      # android/gradle.properties は開発用にABIを4つ残したままにしてある。
       - name: Build Release APK
-        run: cd android && ./gradlew assembleRelease
+        run: cd android && ./gradlew assembleRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
 
       # タグを打たない手動実行でも、成果物を取り出せるようにする
       - name: Upload APK as a workflow artifact


### PR DESCRIPTION
## 何が起きていたか

手動実行した Publish（[run 34298308848](https://github.com/mitsuharu/mobile-printer/actions/runs/34298308848)）の `Build Release APK` が48分走ったのち失敗しました。**キャンセルではありません。** GitHubが付けた注釈はこれです。

> The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.

ランナーのプロセスごと落ちているため、ジョブのログが一切アップロードされていません（`gh run view --log` が `log not found`）。UIでステップが `in_progress` のまま止まって見えるので、キャンセルされたように表示されていました。

| | 所要 | 結果 |
| --- | --- | --- |
| publish の `Build Release APK` | 01:14:19Z → 02:02:31Z = **48分12秒** | ランナー消失 |
| CI の `Build Debug APK`（同じ ubuntu-latest） | 00:20:20Z → 00:41:40Z = **21分20秒** | 成功 |

CIのdebugビルドで21分、`timeout-minutes: 30` の7割を使っています。releaseはこれより重く、余裕がありませんでした。

## 変更点

### 1. ビルドするABIを2つに絞る

`android/gradle.properties` は4 ABI（`armeabi-v7a,arm64-v8a,x86,x86_64`）を指定していて、`newArchEnabled=true` です。`react-native-reanimated`・`react-native-worklets`・`react-native-screens` がそれぞれ `android/src/main/cpp` を持つため、ABIごとにC++を積みます。4 ABI分の並列コンパイルがランナー（public リポジトリの ubuntu-latest は 4 vCPU / 16 GB）のメモリを使い切ります。

`org.gradle.jvmargs=-Xmx2048m` が抑えるのはGradleのJVMだけで、実際にメモリを消費している clang と ninja はその外側で動くため頭打ちになりません。

配布先のSUNMI端末はARMなので、エミュレータ用の `x86` と `x86_64` はワークフローでは作らないことにしました。`android/gradle.properties` は開発時のエミュレータ向けに4 ABIのまま残し、CLIから上書きしています。この上書き方法は `android/gradle.properties` 自身にも記載があります。

```
# Use this property to specify which architecture you want to build.
# You can also override it from the CLI using
# ./gradlew <task> -PreactNativeArchitectures=x86_64
```

### 2. `timeout-minutes` を追加する

`ci.yml` は両ジョブとも指定しているのに、`publish.yml` だけ抜けていました。固まるとGitHubのジョブ上限である6時間まで走り続け、しかも落ちるとログが残らないため原因を追えません。CIのdebugが約21分なので、releaseはその倍を見込んで60分にしています。

## 検証

Gradleの初期化スクリプトで、設定後の `abiFilters` を確認しました。

```
上書きなし:                                              [armeabi-v7a, x86_64, arm64-v8a, x86]
-PreactNativeArchitectures=armeabi-v7a,arm64-v8a:        [armeabi-v7a, arm64-v8a]
```

RNのGradleプラグインが `reactNativeArchitectures` を読んで `defaultConfig.ndk.abiFilters` へ渡しているため（`@react-native/gradle-plugin` の `NdkConfiguratorUtils.kt`）、期待どおり反映されています。

ローカルで実際にリリースビルドも実行しました。

```
BUILD SUCCESSFUL
```

生成されたAPKの中身も確認しています。

```
$ unzip -l app-release.apk | awk '/lib\//{split($4,a,"/"); print a[2]}' | sort -u
arm64-v8a
armeabi-v7a
```

同じ手順で従来どおり4 ABIもビルドし、APKを比較しました。

| ABI | サイズ | 内訳 |
| --- | --- | --- |
| 4 ABI（従来） | 91,688,788 バイト（約87MB） | `armeabi-v7a` `arm64-v8a` `x86` `x86_64` |
| 2 ABI（本PR） | 49,207,055 バイト（約47MB） | `armeabi-v7a` `arm64-v8a` |

配布されるAPKも約46%小さくなります。なおローカルは増分ビルド（661タスクが up-to-date）だったため、ビルド時間の比較にはなっていません。

`yarn typecheck` / `yarn lint` / `yarn test` は実行していません。ワークフローとビルド構成のみの変更で、JavaScript・TypeScriptに変更がないためです。

## 未実施・影響

- **CI上での再実行は未確認です。** ランナーが落ちる問題が実際に解消したかは、このPRをマージしてPublishを手動実行しないと確認できません。メモリ枯渇であるという判断は、GitHubの注釈とビルド構成からの推定です（ログが残っていないため断定はできません）。
- **x86 / x86_64 のエミュレータには、この配布APKをインストールできなくなります。** DeployGate 経由でエミュレータ確認をしている場合は影響します。ローカルの `yarn android` は `android/gradle.properties` の4 ABI設定のままなので、開発時のエミュレータ利用には影響しません。
- 実機での印刷・NFCの動作確認はしていません。アプリのコードには変更がなく、ARM向けの成果物は従来と同じ構成です。
- タイムアウトの60分は、今回の48分と過去の実績からの見積もりです。今後ビルドが重くなった場合は見直しが必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

