### PR TITLE
ci(publish): リリースビルドが通る構成を確保し、原因究明の計測を残す

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,13 +94,23 @@ jobs:
 
       # 製品版ではないため、リリースビルドもコミット済みの debug キーストアで署名する
 
-      # リリースビルド中にランナーが落ちる（The hosted runner lost communication
-      # with the server）。落ちるとジョブのログが保存されないため原因を追えない。
-      # メモリ枯渇とディスク枯渇のどちらもあり得るので、両方に手を打ったうえで、
-      # 次に落ちたときにライブログで判別できるようにする。
+      # リリースビルドのネイティブビルド中にランナーが落ちる
+      # （The hosted runner lost communication with the server）。
+      # 落ちるとジョブのログが保存されず、後から原因を追えない。
+      #
+      # 原因は未特定のまま。ただし実績は次のとおりで、下の2ステップを入れた
+      # 構成でのみリリースビルドが完走している。
+      #
+      #   対処なし  run 34298308848（4 ABI）  失敗
+      #   対処なし  run 34309189757          失敗  app の CMake、約13分
+      #   対処あり  run 34313042301          成功  14分59秒
+      #   対処なし  run 34314606429          失敗  worklets の CMake、約9分
+      #
+      # 落ちる場所も時間も毎回違うため、偶然良いランナーを引いただけの
+      # 可能性も残る。原因が分かるまでは、通る構成を維持する。
 
-      # ルートの空きは14GB程度しかなく、そこへNDK・Gradleキャッシュ・
-      # 各ABIのオブジェクトファイルが乗る。ビルドに使わないものを消す。
+      # ディスクは削除前から85GB空いており、枯渇は考えにくい。
+      # それでも上の実績に含まれる構成のため、切り分けが済むまでは残す。
       - name: Free disk space
         run: |
           echo "--- 削除前 ---"
@@ -110,7 +120,9 @@ jobs:
           echo "--- 削除後 ---"
           df -h /
 
-      # ninja が同時に走らせる clang が使い切る分を、スワップで受ける。
+      # ninja が同時に走らせる clang の分をスワップで受ける。成功した実行では
+      # スワップが使われていなかったが、確保されているだけでカーネルのOOM判定は
+      # 変わるため、効いている可能性が一番高いのはここだと見ている。
       # ランナーには /mnt/swapfile が既にあるため別名で追加する。
       # /mnt はルートとは別ボリュームなので、上の空き容量を圧迫しない。
       - name: Add swap
@@ -124,18 +136,27 @@ jobs:
       # 配布先のSUNMI端末はARMのため、エミュレータ用のx86とx86_64は作らない。
       # android/gradle.properties は開発用にABIを4つ残したままにしてある。
       #
-      # 15秒ごとにメモリとディスクの残量を標準出力へ出す。ジョブのログは
-      # 保存されないが、UIのライブログは落ちる直前まで見えるため、
-      # そこでメモリとディスクのどちらが尽きたかを判別する。
+      # 5秒ごとに資源の残量とメモリ上位のプロセスを標準出力へ出す。ジョブの
+      # ログは保存されないが、UIのライブログは落ちる直前まで見えるため、
+      # 次に落ちたときはその末尾が唯一の手掛かりになる。
+      # 15秒間隔では急な確保を取りこぼすため、5秒まで詰めている。
       - name: Build Release APK
         run: |
-          while true; do
-            echo "[resources] $(date -u +%H:%M:%S)" \
-              "mem_avail=$(free -m | awk '/^Mem:/{print $7}')MB" \
-              "swap_used=$(free -m | awk '/^Swap:/{print $3}')MB" \
-              "disk_avail=$(df -m --output=avail / | tail -1 | tr -d ' ')MB"
-            sleep 15
-          done &
+          # 計測が失敗してもビルドを止めない。サブシェルで set +e にして、
+          # 個々のコマンドが転んでもループ自体は回り続けるようにする。
+          (
+            set +e
+            while true; do
+              echo "[resources] $(date -u +%H:%M:%S)" \
+                "mem_avail=$(free -m | awk '/^Mem:/{print $7}')MB" \
+                "swap_used=$(free -m | awk '/^Swap:/{print $3}')MB" \
+                "disk_avail=$(df -m --output=avail / | tail -1 | tr -d ' ')MB" \
+                "load=$(cut -d' ' -f1-3 /proc/loadavg)" \
+                "top=$(ps -eo rss,comm --sort=-rss --no-headers \
+                       | head -3 | awk '{printf "%s:%dMB ", $2, $1/1024}')"
+              sleep 5
+            done
+          ) &
           sampler=$!
           trap 'kill "$sampler" 2>/dev/null || true' EXIT
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,12 +94,52 @@ jobs:
 
       # 製品版ではないため、リリースビルドもコミット済みの debug キーストアで署名する
 
-      # 4 ABI すべてをビルドするとネイティブのコンパイルがランナーのメモリを使い切り、
-      # ランナーごと落ちる（The hosted runner lost communication with the server）。
+      # リリースビルド中にランナーが落ちる（The hosted runner lost communication
+      # with the server）。落ちるとジョブのログが保存されないため原因を追えない。
+      # メモリ枯渇とディスク枯渇のどちらもあり得るので、両方に手を打ったうえで、
+      # 次に落ちたときにライブログで判別できるようにする。
+
+      # ルートの空きは14GB程度しかなく、そこへNDK・Gradleキャッシュ・
+      # 各ABIのオブジェクトファイルが乗る。ビルドに使わないものを消す。
+      - name: Free disk space
+        run: |
+          echo "--- 削除前 ---"
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost /usr/share/swift
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          echo "--- 削除後 ---"
+          df -h /
+
+      # ninja が同時に走らせる clang が使い切る分を、スワップで受ける。
+      # ランナーには /mnt/swapfile が既にあるため別名で追加する。
+      # /mnt はルートとは別ボリュームなので、上の空き容量を圧迫しない。
+      - name: Add swap
+        run: |
+          sudo fallocate -l 8G /mnt/extra-swapfile
+          sudo chmod 600 /mnt/extra-swapfile
+          sudo mkswap /mnt/extra-swapfile
+          sudo swapon /mnt/extra-swapfile
+          free -h
+
       # 配布先のSUNMI端末はARMのため、エミュレータ用のx86とx86_64は作らない。
       # android/gradle.properties は開発用にABIを4つ残したままにしてある。
+      #
+      # 15秒ごとにメモリとディスクの残量を標準出力へ出す。ジョブのログは
+      # 保存されないが、UIのライブログは落ちる直前まで見えるため、
+      # そこでメモリとディスクのどちらが尽きたかを判別する。
       - name: Build Release APK
-        run: cd android && ./gradlew assembleRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
+        run: |
+          while true; do
+            echo "[resources] $(date -u +%H:%M:%S)" \
+              "mem_avail=$(free -m | awk '/^Mem:/{print $7}')MB" \
+              "swap_used=$(free -m | awk '/^Swap:/{print $3}')MB" \
+              "disk_avail=$(df -m --output=avail / | tail -1 | tr -d ' ')MB"
+            sleep 15
+          done &
+          sampler=$!
+          trap 'kill "$sampler" 2>/dev/null || true' EXIT
+
+          cd android && ./gradlew assembleRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
 
       # タグを打たない手動実行でも、成果物を取り出せるようにする
       - name: Upload APK as a workflow artifact


### PR DESCRIPTION
## 状況

リリースビルドのネイティブビルド中にランナーが落ちます。手動キャンセルではありません。

> The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.

落ちるとジョブのログが保存されないため（`gh run view --log` が `log not found`）、後から原因を追えません。

## 実績

| run | ブランチ | このPRの対処 | 結果 | 落ちた場所 |
| --- | --- | --- | --- | --- |
| [34298308848](https://github.com/mitsuharu/mobile-printer/actions/runs/34298308848) | main | なし（4 ABI） | 失敗 | 不明（ログなし） |
| [34309189757](https://github.com/mitsuharu/mobile-printer/actions/runs/34309189757) | main | なし | 失敗 | app の CMake、約13分 |
| [34313042301](https://github.com/mitsuharu/mobile-printer/actions/runs/34313042301) | このPR | **あり** | **BUILD SUCCESSFUL 14分59秒** | — |
| [34314606429](https://github.com/mitsuharu/mobile-printer/actions/runs/34314606429) | main | なし | 失敗 | worklets の CMake、約9分 |

**対処なしで3回中3回失敗、対処ありで1回中1回成功です。**

なお 34313042301 は `cancelled` で終わっていますが、これは `BUILD SUCCESSFUL` を確認したあと、DeployGate への二重配布を避けるために手で止めたものです。ビルド自体は完走しています。

## 原因は特定できていません

計測の結果、当初の2つの仮説はどちらも外れました。

| 仮説 | 判定 | 根拠 |
| --- | --- | --- |
| ディスク枯渇 | **違う** | 削除前から85GB空いていた（145GB中42%使用） |
| メモリ枯渇 | **断定できない** | 成功した実行では10GB以上空きスワップ未使用。ただしこれは成功した実行のデータでしかない |

初版のコメントには「ルートの空きは14GB程度」と書いていましたが、これは検証していない誤りでした。実測は85GBです。コメントを実測に直しています。

メモリについても、`swap_used=0MB` を根拠に一度は除外しましたが、**それは成功した実行の値であり、失敗する実行で何が起きているかは示していません**。しかも15秒間隔では急な確保を取りこぼします。候補に戻しています。

落ちる場所（app / worklets）も時間（9分・13分・48分）も毎回違うため、**偶然良いランナーを引いただけという可能性も残ります。** 成功はまだ1回です。

## 変更点

### 1. 通る構成を維持する

`Free disk space` と `Add swap` を入れます。原因が説明できていないため本来なら消したいところですが、**唯一リリースビルドが完走した構成がこれ**です。コストは合わせて6秒程度です。コメントには「原因未特定のため、切り分けが済むまで残す」と実態を書いています。

効いている可能性が一番高いのはスワップだと見ています。実際に使われていなくても、確保されているだけでカーネルのOOM判定の挙動は変わるためです。

### 2. 次に落ちたときに証拠を取る

`Build Release APK` と並走して5秒ごとに出力します。

```
[resources] 05:07:32 mem_avail=10874MB swap_used=0MB disk_avail=82738MB load=6.21 4.83 2.55 top=clang++:2140MB clang++:1876MB java:1204MB
```

初版から、間隔を15秒→5秒に詰め、ロードアベレージとメモリ上位3プロセスを追加しました。ジョブのログは保存されませんが、UIのライブログは落ちる直前まで見えます。そこが唯一の手掛かりになります。

計測が失敗してもビルドを止めないよう、サンプラーはサブシェル内で `set +e` にしています。

## 検証

ワークフローのYAMLをパースし、すべての `run` ブロックを `bash -n` で構文検査しました（9ブロック、全てOK）。

サンプラーの構造は等価なスクリプトでローカル検証しています。

```
存在しないコマンドを混ぜてもループは回り続ける → OK
本体が失敗したとき 終了コード=1（ステップは失敗扱い） → OK
本体終了時にサンプラーが残らない → OK
```

`free` `df --output` `ps --sort` はLinux固有のため、ローカル（macOS）では値の確認ができていません。構文と構造のみの検証です。

## 未実施・今後

- **原因は未特定のままです。** このPRは「通る構成の確保」と「次回の証拠取り」であって、根本原因の修正ではありません。
- これでも落ちる場合、次の候補はCPU枯渇です。4 vCPUを ninja が占有してランナーのエージェントがハートビートを落とす筋書きで、注釈が挙げる3つのうち唯一潰せていないものです。対処は ninja の並列度を2に下げる形になります（`android/app/build.gradle` の `externalNativeBuild.cmake.arguments`）。ビルド時間が延びるため `timeout-minutes` の見直しとセットです。
- 逆に安定して通るようになれば、`Free disk space` と `Add swap` を片方ずつ外して、どちらが効いていたのかを切り分けられます。
- 実機での確認はしていません。ワークフローのみの変更で、生成されるAPKの構成は #520 から変わりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
