### PR TITLE
ci(publish): Gradleデーモンを残さないようにする

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,6 +140,13 @@ jobs:
       # ログは保存されないが、UIのライブログは落ちる直前まで見えるため、
       # 次に落ちたときはその末尾が唯一の手掛かりになる。
       # 15秒間隔では急な確保を取りこぼすため、5秒まで詰めている。
+      #
+      # --no-daemon を付ける。Gradleは既定でビルド後もデーモンのJVMを残すが、
+      # それがステップの標準出力を掴んだままだとランナーがジョブを終われない。
+      # run 34318939399 では BUILD SUCCESSFUL のあとリリースと配布まで済んだのに
+      # ジョブが終わらず、タイムアウトを待つことになった。CIの Build Android は
+      # gradle/actions/setup-gradle が後処理でデーモンを止めるため完走している。
+      # CIはジョブごとにランナーを捨てるので、デーモンを残す利点はない。
       - name: Build Release APK
         run: |
           # 計測が失敗してもビルドを止めない。サブシェルで set +e にして、
@@ -160,7 +167,7 @@ jobs:
           sampler=$!
           trap 'kill "$sampler" 2>/dev/null || true' EXIT
 
-          cd android && ./gradlew assembleRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
+          cd android && ./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
 
       # タグを打たない手動実行でも、成果物を取り出せるようにする
       - name: Upload APK as a workflow artifact


### PR DESCRIPTION
## 症状

[run 34318939399](https://github.com/mitsuharu/mobile-printer/actions/runs/34318939399) は、やることを全部終えたのにジョブが終わりませんでした。

- `BUILD SUCCESSFUL in 14m 43s`
- **1.0.1 のリリースは公開済み**（`app-release.apk` 49,207,051バイト、06:40:48Z）
- DeployGate への配布も完了
- それでもジョブが終わらず、`timeout-minutes: 60` を待つことに

**publish の run は過去6回、一度も `Complete job` に到達していません。** 失敗・手動キャンセル・ハングのいずれかで終わっています。

前回 [#525](https://github.com/mitsuharu/mobile-printer/pull/525) で Gradle キャッシュを外したのは、後処理の保存が原因だと見たためでした。**これは誤りでした。** キャッシュを外した回でも同じように終わりませんでした。

## 原因

Gradle は既定で、ビルドが終わってもデーモンのJVMを残します（次回のビルドを速くするため、既定で3時間居座ります）。それがステップの標準出力を掴んだままだと、ランナーは「まだ書き込む人がいる」と判断してジョブを終えられません。

`ci.yml` との比較が裏付けになります。

| | Gradleの起動方法 | ジョブ完了 |
| --- | --- | --- |
| `ci.yml` の Build Android | `gradle/actions/setup-gradle` | **完走する**（`Post Setup Gradle` → `Complete job` まで到達） |
| `publish.yml` | `./gradlew` を直接実行 | **一度も完走していない** |

`gradle/actions/setup-gradle` は後処理でデーモンを止めます。publish にはそれがありませんでした。

## 変更点

```diff
-          cd android && ./gradlew assembleRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
+          cd android && ./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
```

`--no-daemon` は、そのビルド専用のプロセスとして起動し、ビルド終了とともに終了します。何も残りません。

CIはジョブごとにランナーを捨てるため、デーモンを使い回す利点はありません。JVMの再利用がない分わずかに遅くなりますが、毎回1回しかビルドしないので実質的な損はありません。

`ci.yml` と同じく `gradle/actions/setup-gradle` を使う案もありましたが、そちらは既定でGradleキャッシュも扱うため、#525 で外した話と混ざります。まず変数を1つだけ動かして、デーモンが原因かを確かめる形にしました。効かなければ `setup-gradle` に進めます。

## 検証

手元で、通常実行と `--no-daemon` の残存プロセスを比較しました。

```
1) --stop 直後          残存デーモン 0
2) --no-daemon 実行後   残存デーモン 0
3) 通常実行後           残存デーモン 1（PID 6548）
```

通常実行はデーモンを残し、`--no-daemon` は残しません。

ワークフローのYAMLをパースし、全9つの `run` ブロックを `bash -n` で構文検査しています（すべてOK）。

```
gradlew 行: cd android && ./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
```

## 未実施

- **CI上での確認はできていません。** 手元のmacOSでの挙動確認は、Linuxランナーでの代理でしかありません。実際にジョブが `Complete job` まで到達するかは、次の手動実行で確認する必要があります。
- `yarn typecheck` / `yarn lint` / `yarn test` / `assembleDebug` は実行していません。ワークフローのみの変更で、アプリのコードに変更がないためです。
- ランナー消失（`lost communication`）の**根本原因は依然として未特定です。** これはジョブが終わらない件への対処であって、別の問題です。`Free disk space` と `Add swap` は、通る構成を維持するために残しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
