### PR TITLE
ci(publish): DeployGateへ配布するかを手動実行で選べるようにする

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'GitHub Release を作るタグ名（空ならDeployGateへの配布のみ）'
+        description: 'GitHub Release を作るタグ名（空ならReleaseを作らない）'
         required: false
         type: string
       prerelease:
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      upload_to_deploygate:
+        description: 'DeployGateへ配布する（外すとワークフローの動作確認だけになる）'
+        required: false
+        type: boolean
+        default: true
 
   # タグを打つとリリースする。末尾に -beta.1 などが付いたタグはプレリリースになる
   push:
@@ -180,7 +185,10 @@ jobs:
           fail_on_unmatched_files: true
           files: android/app/build/outputs/apk/release/app-release.apk
 
+      # 動作確認のための実行では配布を外せるようにする。タグを打った実行では
+      # inputs が無いため、左の条件だけで真になり、これまでどおり配布する。
       - name: Upload to DeployGate
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_to_deploygate }}
         env:
           DEPLOYGATE_API_KEY: ${{ secrets.DEPLOYGATE_API_KEY }}
           DEPLOYGATE_USER: ${{ secrets.DEPLOYGATE_USER }}


### PR DESCRIPTION
## 背景

ワークフローの動作確認のために publish を回すと、そのたびに DeployGate へ配布されてしまいます。実際、ランナー消失の切り分けで何度も実行した際、確認目的の版が配布対象に混ざりました。前の run を手で止めていただいたのも、二重配布を避けるためでした。

## 変更点

手動実行の入力に `upload_to_deploygate` を足し、`Upload to DeployGate` を条件付きにします。

```yaml
      upload_to_deploygate:
        description: 'DeployGateへ配布する（外すとワークフローの動作確認だけになる）'
        required: false
        type: boolean
        default: true
```

```yaml
      - name: Upload to DeployGate
        if: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_to_deploygate }}
```

**既定は `true`** なので、これまでの実行と挙動は変わりません。確認目的のときだけチェックを外します。

肯定形で持つのは、「配布しない」を既定 `false` で表すと、外すときに否定の否定になって読みづらいためです。条件式も `!( ... == true)` のような形にならず、そのまま読めます。

あわせて `tag` の説明を直しました。「空ならDeployGateへの配布のみ」と書いていましたが、この変更で必ずしもそうではなくなるためです。

## 動きかた

| 実行のしかた | GitHub Release | DeployGate |
| --- | --- | --- |
| タグを push | 作る | **配布する** |
| 手動・タグあり・配布オン（既定） | 作る | **配布する** |
| 手動・タグなし・配布オン（既定） | 作らない | **配布する** |
| 手動・タグなし・配布オフ | 作らない | **配布しない** |

一番下が動作確認用です。ビルドは走り、APKは `Upload APK as a workflow artifact` から取り出せますが、どこにも配布されません。

## 検証

条件式を、GitHubの評価規則に沿って3パターンで確認しました。タグ push では `inputs` コンテキストが無いため、左辺 `github.event_name != 'workflow_dispatch'` だけで真になります。

```
OK  タグ push                   → 配布する
OK  手動・配布する（既定でオン）  → 配布する
OK  手動・配布するを外す         → 配布しない
```

YAMLのパースと入力定義も確認済みです。

```
input tag = string default= なし
input prerelease = boolean default= false
input upload_to_deploygate = boolean default= true
DeployGate if: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_to_deploygate }}
```

## 未実施

- **実際に手動実行しての確認はしていません。** 条件式の評価は手で追ったもので、GitHub上での挙動確認は次の実行時になります。`actionlint` はこの環境に入っていないため、静的検査もかけられていません。
- タグ push 経路には触っていませんが、実際にタグを打っての確認もしていません。条件式が `github.event_name != 'workflow_dispatch'` を含むため、タグ push では必ず配布される作りです。
- `yarn typecheck` / `yarn lint` / `yarn test` / `assembleDebug` は実行していません。ワークフローのみの変更で、アプリのコードに変更がないためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
