### PR TITLE
ci(publish): Gradleの起動方法をci.ymlに揃える

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,12 @@ jobs:
         with:
           node-version-file: '.node-version'
 
+      # ci.yml の Build Android と同じ構成にする。あちらは Complete job まで
+      # 到達するが、publish は一度も到達していない。違いはGradleの起動方法だった。
+      # このアクションは後処理でデーモンを止め、Gradleの実行環境を整える。
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
       - name: Install dependencies
         run: |
           corepack enable
@@ -146,12 +152,9 @@ jobs:
       # 次に落ちたときはその末尾が唯一の手掛かりになる。
       # 15秒間隔では急な確保を取りこぼすため、5秒まで詰めている。
       #
-      # --no-daemon を付ける。Gradleは既定でビルド後もデーモンのJVMを残すが、
-      # それがステップの標準出力を掴んだままだとランナーがジョブを終われない。
-      # run 34318939399 では BUILD SUCCESSFUL のあとリリースと配布まで済んだのに
-      # ジョブが終わらず、タイムアウトを待つことになった。CIの Build Android は
-      # gradle/actions/setup-gradle が後処理でデーモンを止めるため完走している。
-      # CIはジョブごとにランナーを捨てるので、デーモンを残す利点はない。
+      # デーモンの後始末は上の Setup Gradle に任せる。--no-daemon を試したが、
+      # run 34322694091 では BUILD SUCCESSFUL とアーティファクトのアップロードが
+      # 済んだあともジョブが終わらず、効果がなかった。ci.yml も付けていない。
       - name: Build Release APK
         run: |
           # 計測が失敗してもビルドを止めない。サブシェルで set +e にして、
@@ -172,7 +175,7 @@ jobs:
           sampler=$!
           trap 'kill "$sampler" 2>/dev/null || true' EXIT
 
-          cd android && ./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
+          cd android && ./gradlew assembleRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
 
       # タグを打たない手動実行でも、成果物を取り出せるようにする
       - name: Upload APK as a workflow artifact


### PR DESCRIPTION
## 背景

publish のジョブは、やることを全部終えても `Complete job` に到達しません。[run 34322694091](https://github.com/mitsuharu/mobile-printer/actions/runs/34322694091) でも、`BUILD SUCCESSFUL in 15m 13s` のあとアーティファクトのアップロードまで完了しているのに、ステップが閉じませんでした。

```
name=app-release size=24777690 created=2026-09-09T07:28:49Z workflow_run_id=34322694091
```

一方で `ci.yml` の Build Android は完走します。両者の違いはGradleの起動方法でした。

| | Gradleの起動方法 | ジョブ完了 |
| --- | --- | --- |
| `ci.yml` の Build Android | `gradle/actions/setup-gradle` | **到達する** |
| `publish.yml` | `./gradlew` を直接実行 | **7回とも到達していない** |

## 変更点

**1. `Setup Gradle` を追加。** `ci.yml` と同じアクション、同じSHAです。

```yaml
      - name: Setup Gradle
        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
```

**2. `--no-daemon` を外す。** [#527](https://github.com/mitsuharu/mobile-printer/pull/527) でデーモンが原因という見立てで入れましたが、**効果がありませんでした。** `ci.yml` も付けていないため、揃える意味でも外します。デーモンの後始末はアクションに任せます。

## 補足

このアクションは既定でGradleのキャッシュを扱います。[#525](https://github.com/mitsuharu/mobile-printer/pull/525) で `actions/cache` による `~/.gradle/caches` のキャッシュを外したばかりですが、こちらは仕組みが別で、対象を絞って扱います。`ci.yml` での実績では **`Post Setup Gradle` は0秒**（`00:42:22Z -> 00:42:22Z`）なので、#525 で問題にした「保存に10分以上かかる」状況にはならない見込みです。

`cache-disabled: true` で無効にもできますが、「`ci.yml` に揃える」という趣旨から、あちらと同じくオプションなしにしています。

## 検証

`ci.yml` とアクションのSHAが一致することを確認しました。

```
publish の Setup Gradle: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
ci      の Setup Gradle: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
一致: はい
```

AGENTS.md の規約どおり、SHA固定とバージョンコメント（`# v6.3.0`）を付けています。YAMLのパースと、全9つの `run` ブロックの `bash -n` も通っています。

## 未実施・注意

- **これで直るかは分かりません。** 「動いている構成をそのまま持ってくる」という判断であって、原因を特定したわけではありません。
- **原因は依然として未特定です。** run 34322694091 では、UI上のステップ一覧が凍結したまま、実際にはアーティファクトのアップロードが完了していました。つまりランナーは作業を進めているのにサーバーへ報告できていません。これは追いかけてきた `The hosted runner lost communication with the server` と同じ現象の可能性があります。だとすると、このPRでも直りません。
- その場合に残る唯一の未検証の筋はCPU枯渇です。`[resources]` の `load` は 5.79 と4コアに対して過負荷でした。ninja の同時コンパイル数を制限して、ランナーのエージェント用にCPUを残す対処になります。
- `yarn typecheck` / `yarn lint` / `yarn test` / `assembleDebug` は実行していません。ワークフローのみの変更で、アプリのコードに変更がないためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
