### PR TITLE
ci(publish): システムを変更する操作をやめてci.ymlに寄せる

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,11 +78,12 @@ jobs:
           yarn typecheck
           yarn lint
 
-      # 時間関連のテスト向けにタイムゾーンを固定する
-      - name: Set timezone to Asia/Tokyo
-        run: sudo timedatectl set-timezone Asia/Tokyo
-
+      # 時間関連のテスト向けにタイムゾーンを固定する。
+      # sudo timedatectl でシステムの時刻設定を書き換えていたが、ci.yml と同じく
+      # 環境変数で渡す。テストへの効果は同じで、ランナーのシステムを触らない。
       - name: Run test
+        env:
+          TZ: Asia/Tokyo
         run: |
           yarn test
 
@@ -101,48 +102,24 @@ jobs:
 
       # 製品版ではないため、リリースビルドもコミット済みの debug キーストアで署名する
 
-      # リリースビルドのネイティブビルド中にランナーが落ちる
+      # publish は8回すべてでランナーとの通信が切れている
       # （The hosted runner lost communication with the server）。
       # 落ちるとジョブのログが保存されず、後から原因を追えない。
       #
-      # 原因は未特定のまま。ただし実績は次のとおりで、下の2ステップを入れた
-      # 構成でのみリリースビルドが完走している。
+      # 資源の枯渇は計測で否定した。run 34325396782 の死ぬ直前の値は
+      # メモリ空き11.4GB、スワップ使用0MB、ディスク空き83GB、load 4.36 で、
+      # どれも逼迫していない。ディスクを空ける・スワップを足す対処は
+      # 効いていなかったため外した。
       #
-      #   対処なし  run 34298308848（4 ABI）  失敗  ランナー消失、約48分
-      #   対処なし  run 34309189757          失敗  ランナー消失、app の CMake、約13分
-      #   対処あり  run 34313042301          成功  ビルド14分59秒
-      #   対処なし  run 34314606429          失敗  worklets の CMake、約9分
-      #                                            ランナーが応答しなくなり、GitHubが
-      #                                            判定する前に手で止めたため、注釈は
-      #                                            canceled by となっている
-      #   対処あり  run 34315640308          成功  ビルド15分14秒、配布まで完了
+      # 一方 ci.yml の Build Android は同じ ubuntu-latest で完走し続けている。
+      # 差分を洗ったところ、publish にだけ sudo でシステムを変更する操作が
+      # あった（timedatectl によるタイムゾーン変更）。これは publish.yml の
+      # 追加時からあり、失敗した8回すべてに存在する。ci.yml に sudo は無い。
+      # ランナーのエージェントは短命なトークンで通信を維持しているため、
+      # 時刻まわりを触ると接続が壊れ得る。死ぬまでの時間が4.5分から48分まで
+      # ばらつくのも、周期的な処理が来たときに初めて破綻するなら説明がつく。
       #
-      # 落ちる場所も時間も毎回違うため、偶然良いランナーを引いただけの
-      # 可能性も残る。原因が分かるまでは、通る構成を維持する。
-
-      # ディスクは削除前から85GB空いており、枯渇は考えにくい。
-      # それでも上の実績に含まれる構成のため、切り分けが済むまでは残す。
-      - name: Free disk space
-        run: |
-          echo "--- 削除前 ---"
-          df -h /
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost /usr/share/swift
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          echo "--- 削除後 ---"
-          df -h /
-
-      # ninja が同時に走らせる clang の分をスワップで受ける。成功した実行では
-      # スワップが使われていなかったが、確保されているだけでカーネルのOOM判定は
-      # 変わるため、効いている可能性が一番高いのはここだと見ている。
-      # ランナーには /mnt/swapfile が既にあるため別名で追加する。
-      # /mnt はルートとは別ボリュームなので、上の空き容量を圧迫しない。
-      - name: Add swap
-        run: |
-          sudo fallocate -l 8G /mnt/extra-swapfile
-          sudo chmod 600 /mnt/extra-swapfile
-          sudo mkswap /mnt/extra-swapfile
-          sudo swapon /mnt/extra-swapfile
-          free -h
+      # 機序は未証明。ci.yml に揃えて sudo を無くし、様子を見る。
 
       # 配布先のSUNMI端末はARMのため、エミュレータ用のx86とx86_64は作らない。
       # android/gradle.properties は開発用にABIを4つ残したままにしてある。


### PR DESCRIPTION
## 見つけたこと

publish は **8回すべて**でランナーとの通信が切れています。一方 `ci.yml` の Build Android は同じ `ubuntu-latest` で完走し続けています。両者を機械的に突き合わせたところ、**publish にだけ sudo でシステムを変更する操作がありました。**

```
=== publish だけにある sudo 操作 ===
83:  sudo timedatectl set-timezone Asia/Tokyo      ← publish.yml 追加時からある
129: sudo rm -rf /usr/share/dotnet ...             ← 切り分けのために私が追加
141: sudo fallocate / mkswap / swapon              ← 同上

=== ci.yml に sudo はあるか ===
  なし
```

`ci.yml` は同じタイムゾーン固定を、システムではなく環境変数で済ませています。

```yaml
  test:
    env:
      TZ: Asia/Tokyo
```

`timedatectl` は [`bebcb7b add publish.yml`](https://github.com/mitsuharu/mobile-printer/commit/bebcb7b) からあり、**失敗した8回すべてに存在します。** 私が追加した2つは最初の失敗より後なので、元凶ではありません。

ランナーのエージェントは短命なトークンで GitHub との通信を維持しています。時刻まわりを触ると接続が壊れ得ます。**死ぬまでの時間が4.5分から48分までばらついていた**のも、変更の瞬間ではなく、その後の周期的な処理が来たときに初めて破綻するなら説明がつきます。

## 資源の枯渇は計測で否定済み

[run 34325396782](https://github.com/mitsuharu/mobile-printer/actions/runs/34325396782) で、死ぬ直前の値が取れました。

```
[resources] 07:56:07 mem_avail=11413MB swap_used=0MB disk_avail=83233MB
            load=4.36 2.39 1.03 top=java:1917MB java:1009MB clang++:292MB
Error: The operation was canceled.
```

| 資源 | 値 | 判定 |
| --- | --- | --- |
| メモリ | 空き11.4GB、スワップ使用0MB | 枯渇していない |
| ディスク | 空き83GB | 枯渇していない |
| CPU | load 4.36（4コア） | 使い切ってはいるが、ビルド中として異常ではない |

**私が入れた `Free disk space` と `Add swap` は効いていませんでした。**

## 変更点

| 変更 | 理由 |
| --- | --- |
| `sudo timedatectl` → `Run test` の `env: TZ: Asia/Tokyo` | `ci.yml` と同じ方式。テストへの効果は同じで、システムを触らない |
| `Free disk space` を削除 | 計測で否定された。かつ sudo 操作 |
| `Add swap` を削除 | 同上 |

`[resources]` のサンプラーは残します。唯一の証拠源として実際に機能しています。

## 検証

`ci.yml` との差分を確認しました。

```
sudo を実行するステップ
  ci     : なし
  publish: なし

セットアップ系アクションの SHA 比較
  checkout      一致
  setup-node    一致
  setup-java    一致
  setup-gradle  一致

Gradle 実行
  ci     : cd android && ./gradlew assembleDebug
  publish: cd android && ./gradlew assembleRelease -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
```

**publish の sudo はゼロになり、残る差は Gradle のタスクだけになりました。**

YAMLのパースと、全6つの `run` ブロックの `bash -n` も通っています。

## 未実施・注意

- **機序は証明できていません。** `timedatectl` が通信断を起こすという因果は示せておらず、相関が強いという段階です。これまで私の見立ては5回外れています。
- ただし今回は、これまでの推測と違い **「ci は成功して publish は失敗する」という差分そのものから出てきた仮説**です。かつ、この変更は仮説が外れていても損がありません（`ci.yml` と同じ方式に揃うだけで、テストのタイムゾーンは維持されます）。
- これでも落ちる場合、残る差は `assembleRelease` と `assembleDebug` だけになります。次はABIを1つに減らして露出時間を縮めるか、GitHubのサポートへ計測データとともに問い合わせる段階だと思います。
- `yarn typecheck` / `yarn lint` / `yarn test` / `assembleDebug` は実行していません。ワークフローのみの変更で、アプリのコードに変更がないためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
