### PR TITLE
chore(release): バージョンを1.0.2にする

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,8 +82,8 @@ android {
         applicationId "com.mobpri"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3
-        versionName "1.0.1"
+        versionCode 4
+        versionName "1.0.2"
     }
     signingConfigs {
         debug {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobpri",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## 変更概要

1.0.1 を配布したため、次のバージョンへ上げます。

| ファイル | 変更 |
| --- | --- |
| `android/app/build.gradle` | `versionCode 3` → `4`、`versionName "1.0.1"` → `"1.0.2"` |
| `package.json` | `"version": "1.0.1"` → `"1.0.2"` |

`versionCode` は配布済みのビルドが 3 のため、更新として扱われるよう 4 にします。

`package.json` もあわせて変更しています。[`6752120`](https://github.com/mitsuharu/mobile-printer/commit/675212022f170bda95f94eb9bc90f9c03edc2694)（1.0 → 1.0.0）と [#526](https://github.com/mitsuharu/mobile-printer/pull/526)（1.0.0 → 1.0.1）が同じ2ファイルを触っており、それに倣いました。

## 表示への反映

アプリ内の「このアプリについて」は [`AppInfo/index.tsx:88`](src/screens/AppInfo/index.tsx:88) でこう組み立てています。

```ts
const version = useMemo(() => `${getVersion()} (${getBuildNumber()})`, [])
```

`react-native-device-info` がネイティブから読むため、`1.0.2 (4)` と表示されます。

## 検証

ビルドした APK のマニフェストを直接確認しました。

```
$ aapt2 dump badging app-debug.apk
package: name='com.mobpri' versionCode='4' versionName='1.0.2' ...
```

必須の検証も実行しています。

```
yarn typecheck   … 出力なし（成功）
yarn lint        … exit 0
TZ=Asia/Tokyo yarn test --runInBand
  Test Suites: 23 passed, 23 total
  Tests:       240 passed, 240 total
(cd android && ./gradlew assembleDebug)
  BUILD SUCCESSFUL
```

## 未実施

- 実機での確認はしていません。「このアプリについて」の表示は `react-native-device-info` 経由で、APKのマニフェストに正しい値が入っていることは上記で確認済みです。
- **タグの作成とリリースは行っていません。** AGENTS.md のとおりメンテナーの操作です。このPRをマージしたあと、`1.0.2` のタグを push するか `workflow_dispatch` で Publish を実行してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
